### PR TITLE
Replace Ollama embedding with on-device Nomic via swift-embeddings

### DIFF
--- a/NewsCombApp.xcodeproj/project.pbxproj
+++ b/NewsCombApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		490FA38C2F1B7D1200BAEBFC /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 490FA38B2F1B7D1200BAEBFC /* GRDB */; };
 		490FA38E2F1B7D1200BAEBFC /* SQLiteExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 490FA38D2F1B7D1200BAEBFC /* SQLiteExtensions */; };
 		490FA3912F1B7E1000BAEBFC /* HyperGraphReasoning in Frameworks */ = {isa = PBXBuildFile; productRef = 490FA3902F1B7E1000BAEBFC /* HyperGraphReasoning */; };
+		490FA3942F1B7E2000BAEBFC /* Embeddings in Frameworks */ = {isa = PBXBuildFile; productRef = 490FA3932F1B7E2000BAEBFC /* Embeddings */; };
 		491E2BE32F16EC2300D1840C /* FeedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0000000000000000000021 /* FeedKit */; };
 		491E2BE42F16EC2300D1840C /* PostlightSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0000000000000000000050 /* PostlightSwift */; };
 /* End PBXBuildFile section */
@@ -88,6 +89,7 @@
 			files = (
 				490FA3912F1B7E1000BAEBFC /* HyperGraphReasoning in Frameworks */,
 				490FA38C2F1B7D1200BAEBFC /* GRDB in Frameworks */,
+				490FA3942F1B7E2000BAEBFC /* Embeddings in Frameworks */,
 				491E2BE42F16EC2300D1840C /* PostlightSwift in Frameworks */,
 				490FA38E2F1B7D1200BAEBFC /* SQLiteExtensions in Frameworks */,
 				491E2BE32F16EC2300D1840C /* FeedKit in Frameworks */,
@@ -165,6 +167,7 @@
 				490FA38B2F1B7D1200BAEBFC /* GRDB */,
 				490FA38D2F1B7D1200BAEBFC /* SQLiteExtensions */,
 				490FA3902F1B7E1000BAEBFC /* HyperGraphReasoning */,
+				490FA3932F1B7E2000BAEBFC /* Embeddings */,
 			);
 			productName = NewsCombApp;
 			productReference = 8A0000000000000000000001 /* NewsCombApp.app */;
@@ -249,6 +252,7 @@
 				8A0000000000000000000051 /* XCRemoteSwiftPackageReference "postlight-swift" */,
 				490FA38A2F1B7D1200BAEBFC /* XCLocalSwiftPackageReference "GRDBCustom" */,
 				490FA38F2F1B7E1000BAEBFC /* XCLocalSwiftPackageReference "../HyperGraphReasoning/hypergraph-reasoning-swift" */,
+				490FA3922F1B7E2000BAEBFC /* XCRemoteSwiftPackageReference "swift-embeddings" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8A0000000000000000000005 /* Products */;
@@ -647,6 +651,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		490FA3922F1B7E2000BAEBFC /* XCRemoteSwiftPackageReference "swift-embeddings" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jkrukowski/swift-embeddings";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.16;
+			};
+		};
 		8A0000000000000000000023 /* XCRemoteSwiftPackageReference "FeedKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nmdias/FeedKit";
@@ -677,6 +689,11 @@
 		490FA3902F1B7E1000BAEBFC /* HyperGraphReasoning */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = HyperGraphReasoning;
+		};
+		490FA3932F1B7E2000BAEBFC /* Embeddings */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 490FA3922F1B7E2000BAEBFC /* XCRemoteSwiftPackageReference "swift-embeddings" */;
+			productName = Embeddings;
 		};
 		8A0000000000000000000021 /* FeedKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NewsCombApp/Models/AppSettings.swift
+++ b/NewsCombApp/Models/AppSettings.swift
@@ -34,18 +34,15 @@ extension AppSettings {
 
     // Embedding Configuration
     static let embeddingProvider = "embedding_provider"
-    static let defaultEmbeddingProvider = "ollama"
-    static let embeddingOllamaEndpoint = "embedding_ollama_endpoint"
-    static let defaultEmbeddingOllamaEndpoint = "http://localhost:11434"
-    static let embeddingOllamaModel = "embedding_ollama_model"
-    static let defaultEmbeddingOllamaModel = "nomic-embed-text:v1.5"
+    static let defaultEmbeddingProvider = "nomic"
     static let embeddingOpenRouterModel = "embedding_openrouter_model"
     static let defaultEmbeddingOpenRouterModel = "openai/text-embedding-3-large"
     static let embeddingDimension = "embedding_dimension"
     /// Maximum embedding dimension: (8192 - RelationFamily.count) / 3 ≈ 2726.
     /// Event vectors concatenate 3× the embedding + a one-hot, and sqlite-vec caps at 8192.
     static let maxEmbeddingDimension = 2560  // largest multiple of 256 that fits
-    static let defaultEmbeddingDimension = 1536
+    /// Default dimension matches the on-device Nomic Embed Text v1.5 model (768-d).
+    static let defaultEmbeddingDimension = 768
     /// Tracks the dimension the vec0 virtual tables were created with.
     /// Used to detect when tables need to be recreated after a dimension change.
     static let activeEmbeddingDimension = "active_embedding_dimension"

--- a/NewsCombApp/Services/DatabaseService.swift
+++ b/NewsCombApp/Services/DatabaseService.swift
@@ -524,8 +524,6 @@ public final class Database: Sendable {
 
             // Embedding Configuration
             (AppSettings.embeddingProvider, AppSettings.defaultEmbeddingProvider),
-            (AppSettings.embeddingOllamaEndpoint, AppSettings.defaultEmbeddingOllamaEndpoint),
-            (AppSettings.embeddingOllamaModel, AppSettings.defaultEmbeddingOllamaModel),
             (AppSettings.embeddingOpenRouterModel, AppSettings.defaultEmbeddingOpenRouterModel),
             (AppSettings.embeddingDimension, String(AppSettings.defaultEmbeddingDimension)),
 

--- a/NewsCombApp/Services/GraphRAGService.swift
+++ b/NewsCombApp/Services/GraphRAGService.swift
@@ -331,7 +331,7 @@ final class GraphRAGService: Sendable {
         }
     }
 
-    /// Generates an embedding using the configured provider (Ollama or OpenRouter).
+    /// Generates an embedding using the configured provider (Nomic on-device or OpenRouter).
     @MainActor
     private func embedText(_ text: String, settings: LLMSettings) async throws -> [Float] {
         if settings.embeddingProvider == "openrouter" {
@@ -346,16 +346,7 @@ final class GraphRAGService: Sendable {
             )
             return try await service.embed(text)
         } else {
-            let embeddingEndpoint = settings.embeddingOllamaEndpoint ?? settings.ollamaEndpoint ?? AppSettings.defaultEmbeddingOllamaEndpoint
-            let embeddingModel = settings.embeddingOllamaModel ?? AppSettings.defaultEmbeddingOllamaModel
-
-            let ollama: OllamaService
-            if let host = URL(string: embeddingEndpoint) {
-                ollama = OllamaService(host: host, embeddingModel: embeddingModel)
-            } else {
-                ollama = OllamaService(embeddingModel: embeddingModel)
-            }
-            return try await ollama.embed(text)
+            return try await NomicEmbeddingService.shared.embed(text)
         }
     }
 
@@ -1014,19 +1005,8 @@ final class GraphRAGService: Sendable {
             if let provider = try AppSettings
                 .filter(AppSettings.Columns.key == AppSettings.embeddingProvider)
                 .fetchOne(db) {
-                settings.embeddingProvider = provider.value
-            }
-
-            if let endpoint = try AppSettings
-                .filter(AppSettings.Columns.key == AppSettings.embeddingOllamaEndpoint)
-                .fetchOne(db) {
-                settings.embeddingOllamaEndpoint = endpoint.value
-            }
-
-            if let model = try AppSettings
-                .filter(AppSettings.Columns.key == AppSettings.embeddingOllamaModel)
-                .fetchOne(db) {
-                settings.embeddingOllamaModel = model.value
+                // Migrate legacy "ollama" provider to "nomic"
+                settings.embeddingProvider = provider.value == "ollama" ? "nomic" : provider.value
             }
 
             if let model = try AppSettings

--- a/NewsCombApp/Services/HypergraphService.swift
+++ b/NewsCombApp/Services/HypergraphService.swift
@@ -298,19 +298,17 @@ final class HypergraphService: Sendable {
         logger.info("Embedding Provider: \(settings.embeddingProvider, privacy: .public)")
 
         // DocumentProcessor requires an OllamaService for its internal embedding pipeline.
-        // When embedding provider is OpenRouter, we still create an Ollama service as a
-        // placeholder — the embeddings it produces are discarded in persistHypergraph
-        // and re-generated via the configured provider.
-        let embeddingEndpoint = settings.embeddingOllamaEndpoint ?? settings.ollamaEndpoint ?? AppSettings.defaultEmbeddingOllamaEndpoint
-        let embeddingModel = settings.embeddingOllamaModel ?? AppSettings.defaultEmbeddingOllamaModel
-        let embeddingHost = URL(string: embeddingEndpoint) ?? URL(string: AppSettings.defaultEmbeddingOllamaEndpoint)!
-        let embeddingOllama = OllamaService(host: embeddingHost, embeddingModel: embeddingModel)
+        // The embeddings it produces are discarded in persistHypergraph and re-generated
+        // via the configured embedding provider (Nomic on-device or OpenRouter).
+        let placeholderEndpoint = settings.ollamaEndpoint ?? AppSettings.defaultOllamaEndpoint
+        let placeholderHost = URL(string: placeholderEndpoint) ?? URL(string: AppSettings.defaultOllamaEndpoint)!
+        let embeddingOllama = OllamaService(host: placeholderHost)
 
         switch settings.provider {
         case "ollama":
             let endpoint = settings.ollamaEndpoint ?? AppSettings.defaultOllamaEndpoint
             let model = settings.ollamaModel ?? AppSettings.defaultOllamaModel
-            logger.info("Configuring Ollama: endpoint=\(endpoint, privacy: .public), model=\(model, privacy: .public), embedding=\(embeddingModel, privacy: .public)")
+            logger.info("Configuring Ollama: endpoint=\(endpoint, privacy: .public), model=\(model, privacy: .public)")
 
             if let extractionPrompt = settings.extractionSystemPrompt {
                 logger.info("Using custom extraction prompt (\(extractionPrompt.count) chars)")
@@ -320,7 +318,6 @@ final class HypergraphService: Sendable {
             let ollama = OllamaService(
                 host: host,
                 chatModel: model,
-                embeddingModel: embeddingModel,
                 temperature: settings.extractionTemperature
             )
             return DocumentProcessor(
@@ -377,18 +374,8 @@ final class HypergraphService: Sendable {
             logger.info("Embedding via OpenRouter: model=\(model, privacy: .public), dim=\(settings.embeddingDimension)")
             return try await service.embed(text)
         } else {
-            let embeddingEndpoint = settings.embeddingOllamaEndpoint ?? settings.ollamaEndpoint ?? AppSettings.defaultEmbeddingOllamaEndpoint
-            let embeddingModel = settings.embeddingOllamaModel ?? AppSettings.defaultEmbeddingOllamaModel
-
-            logger.info("Embedding via Ollama: endpoint=\(embeddingEndpoint, privacy: .public), model=\(embeddingModel, privacy: .public)")
-
-            let ollama: OllamaService
-            if let host = URL(string: embeddingEndpoint) {
-                ollama = OllamaService(host: host, embeddingModel: embeddingModel)
-            } else {
-                ollama = OllamaService(embeddingModel: embeddingModel)
-            }
-            return try await ollama.embed(text)
+            logger.info("Embedding via on-device Nomic: \(NomicEmbeddingService.modelName, privacy: .public)")
+            return try await NomicEmbeddingService.shared.embed(text)
         }
     }
 
@@ -407,16 +394,7 @@ final class HypergraphService: Sendable {
             )
             return try await service.embed(texts)
         } else {
-            let embeddingEndpoint = settings.embeddingOllamaEndpoint ?? settings.ollamaEndpoint ?? AppSettings.defaultEmbeddingOllamaEndpoint
-            let embeddingModel = settings.embeddingOllamaModel ?? AppSettings.defaultEmbeddingOllamaModel
-
-            let ollama: OllamaService
-            if let host = URL(string: embeddingEndpoint) {
-                ollama = OllamaService(host: host, embeddingModel: embeddingModel)
-            } else {
-                ollama = OllamaService(embeddingModel: embeddingModel)
-            }
-            return try await ollama.embed(texts)
+            return try await NomicEmbeddingService.shared.embed(texts)
         }
     }
 
@@ -459,19 +437,8 @@ final class HypergraphService: Sendable {
             if let provider = try AppSettings
                 .filter(AppSettings.Columns.key == AppSettings.embeddingProvider)
                 .fetchOne(db) {
-                settings.embeddingProvider = provider.value
-            }
-
-            if let endpoint = try AppSettings
-                .filter(AppSettings.Columns.key == AppSettings.embeddingOllamaEndpoint)
-                .fetchOne(db) {
-                settings.embeddingOllamaEndpoint = endpoint.value
-            }
-
-            if let model = try AppSettings
-                .filter(AppSettings.Columns.key == AppSettings.embeddingOllamaModel)
-                .fetchOne(db) {
-                settings.embeddingOllamaModel = model.value
+                // Migrate legacy "ollama" provider to "nomic"
+                settings.embeddingProvider = provider.value == "ollama" ? "nomic" : provider.value
             }
 
             if let model = try AppSettings
@@ -541,9 +508,7 @@ final class HypergraphService: Sendable {
                     .filter(AppSettings.Columns.key == AppSettings.embeddingOpenRouterModel)
                     .fetchOne(db)?.value ?? AppSettings.defaultEmbeddingOpenRouterModel
             } else {
-                return try AppSettings
-                    .filter(AppSettings.Columns.key == AppSettings.embeddingOllamaModel)
-                    .fetchOne(db)?.value ?? AppSettings.defaultEmbeddingOllamaModel
+                return NomicEmbeddingService.modelName
             }
         }
     }
@@ -1207,9 +1172,7 @@ struct LLMSettings: Sendable {
     var openRouterModel: String?
 
     // Embedding configuration
-    var embeddingProvider: String = "ollama"
-    var embeddingOllamaEndpoint: String?
-    var embeddingOllamaModel: String?
+    var embeddingProvider: String = "nomic"
     var embeddingOpenRouterModel: String?
     var embeddingDimension: Int = AppSettings.defaultEmbeddingDimension
 

--- a/NewsCombApp/Services/NomicEmbeddingService.swift
+++ b/NewsCombApp/Services/NomicEmbeddingService.swift
@@ -1,0 +1,79 @@
+import Embeddings
+import Foundation
+import OSLog
+
+/// On-device embedding service using the Nomic Embed Text v1.5 model
+/// via the `swift-embeddings` library and Apple's MLTensor.
+///
+/// The model is lazily downloaded from Hugging Face Hub on first use
+/// and cached for the lifetime of the process.
+final class NomicEmbeddingService: Sendable {
+    /// The Hugging Face model identifier.
+    static let modelName = "nomic-ai/nomic-embed-text-v1.5"
+
+    /// The fixed embedding dimension produced by nomic-embed-text-v1.5.
+    static let embeddingDimension = 768
+
+    private let logger = Logger(subsystem: "com.newscomb.app", category: "NomicEmbedding")
+
+    /// Shared singleton — safe to reuse across the app.
+    static let shared = NomicEmbeddingService()
+
+    /// Lazily loaded model bundle, protected by an actor for thread-safe
+    /// one-time initialization.
+    private let modelHolder = ModelHolder()
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Embeds a single text string, returning a Float array of dimension 768.
+    @concurrent
+    func embed(_ text: String) async throws -> [Float] {
+        let bundle = try await modelHolder.modelBundle(logger: logger)
+        let tensor = try bundle.encode(text)
+        return await tensor.cast(to: Float.self).shapedArray(of: Float.self).scalars
+    }
+
+    /// Embeds multiple text strings, returning an array of Float arrays.
+    @concurrent
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        guard !texts.isEmpty else { return [] }
+
+        let bundle = try await modelHolder.modelBundle(logger: logger)
+
+        // Process texts individually to get separate embedding vectors.
+        // batchEncode returns a single 2D tensor but extracting rows requires
+        // dimension slicing which is simpler done per-text for correctness.
+        var results: [[Float]] = []
+        results.reserveCapacity(texts.count)
+
+        for text in texts {
+            let tensor = try bundle.encode(text)
+            let scalars = await tensor.cast(to: Float.self).shapedArray(of: Float.self).scalars
+            results.append(scalars)
+        }
+        return results
+    }
+}
+
+// MARK: - Model Holder Actor
+
+/// Actor that ensures the model bundle is loaded exactly once.
+private actor ModelHolder {
+    private var cachedBundle: NomicBert.ModelBundle?
+
+    func modelBundle(logger: Logger) async throws -> NomicBert.ModelBundle {
+        if let cachedBundle {
+            return cachedBundle
+        }
+
+        logger.info("Loading Nomic embedding model from Hugging Face Hub: \(NomicEmbeddingService.modelName, privacy: .public)")
+        let bundle = try await NomicBert.loadModelBundle(
+            from: NomicEmbeddingService.modelName
+        )
+        cachedBundle = bundle
+        logger.info("Nomic embedding model loaded successfully")
+        return bundle
+    }
+}

--- a/NewsCombApp/ViewModels/SettingsViewModel.swift
+++ b/NewsCombApp/ViewModels/SettingsViewModel.swift
@@ -21,14 +21,14 @@ enum LLMProviderOption: String, CaseIterable, Identifiable {
 
 /// Embedding provider options.
 enum EmbeddingProviderOption: String, CaseIterable, Identifiable {
-    case ollama = "ollama"
+    case nomic = "nomic"
     case openrouter = "openrouter"
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .ollama: return "Ollama (Local)"
+        case .nomic: return "Nomic (On-Device)"
         case .openrouter: return "OpenRouter (Cloud)"
         }
     }
@@ -66,9 +66,7 @@ class SettingsViewModel {
     var openRouterModel: String = AppSettings.defaultOpenRouterModel
 
     // Embedding Configuration
-    var embeddingProvider: EmbeddingProviderOption = .ollama
-    var embeddingOllamaEndpoint: String = AppSettings.defaultEmbeddingOllamaEndpoint
-    var embeddingOllamaModel: String = AppSettings.defaultEmbeddingOllamaModel
+    var embeddingProvider: EmbeddingProviderOption = .nomic
     var embeddingOpenRouterModel: String = AppSettings.defaultEmbeddingOpenRouterModel
     var embeddingDimension: Int = AppSettings.defaultEmbeddingDimension
 
@@ -143,15 +141,9 @@ class SettingsViewModel {
 
                 // Load embedding settings
                 if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.embeddingProvider).fetchOne(db) {
-                    embeddingProvider = EmbeddingProviderOption(rawValue: setting.value) ?? .ollama
-                }
-
-                if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.embeddingOllamaEndpoint).fetchOne(db) {
-                    embeddingOllamaEndpoint = setting.value
-                }
-
-                if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.embeddingOllamaModel).fetchOne(db) {
-                    embeddingOllamaModel = setting.value
+                    // Migrate legacy "ollama" provider to "nomic"
+                    let raw = setting.value == "ollama" ? "nomic" : setting.value
+                    embeddingProvider = EmbeddingProviderOption(rawValue: raw) ?? .nomic
                 }
 
                 if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.embeddingOpenRouterModel).fetchOne(db) {
@@ -362,14 +354,6 @@ class SettingsViewModel {
 
     func saveEmbeddingProvider() {
         saveAPIKey(key: AppSettings.embeddingProvider, value: embeddingProvider.rawValue)
-    }
-
-    func saveEmbeddingOllamaEndpoint() {
-        saveAPIKey(key: AppSettings.embeddingOllamaEndpoint, value: embeddingOllamaEndpoint)
-    }
-
-    func saveEmbeddingOllamaModel() {
-        saveAPIKey(key: AppSettings.embeddingOllamaModel, value: embeddingOllamaModel)
     }
 
     func saveEmbeddingOpenRouterModel() {

--- a/NewsCombApp/Views/SettingsView.swift
+++ b/NewsCombApp/Views/SettingsView.swift
@@ -106,17 +106,11 @@ struct SettingsView: View {
                 viewModel.saveEmbeddingProvider()
             }
 
-            if viewModel.embeddingProvider == .ollama {
-                TextField("Embedding Endpoint", text: $viewModel.embeddingOllamaEndpoint)
-                    .textContentType(.URL)
-                    .onChange(of: viewModel.embeddingOllamaEndpoint) {
-                        viewModel.saveEmbeddingOllamaEndpoint()
-                    }
-
-                TextField("Embedding Model", text: $viewModel.embeddingOllamaModel)
-                    .onChange(of: viewModel.embeddingOllamaModel) {
-                        viewModel.saveEmbeddingOllamaModel()
-                    }
+            if viewModel.embeddingProvider == .nomic {
+                LabeledContent("Embedding Model", value: NomicEmbeddingService.modelName)
+                    .foregroundStyle(.secondary)
+                LabeledContent("Embedding Dimensions", value: "\(NomicEmbeddingService.embeddingDimension)")
+                    .foregroundStyle(.secondary)
             }
 
             if viewModel.embeddingProvider == .openrouter {
@@ -124,23 +118,27 @@ struct SettingsView: View {
                     .onChange(of: viewModel.embeddingOpenRouterModel) {
                         viewModel.saveEmbeddingOpenRouterModel()
                     }
-            }
 
-            Stepper(value: $viewModel.embeddingDimension, in: 256...AppSettings.maxEmbeddingDimension, step: 256) {
-                HStack {
-                    Text("Embedding Dimensions")
-                    Spacer()
-                    Text("\(viewModel.embeddingDimension)")
-                        .foregroundStyle(.secondary)
+                Stepper(value: $viewModel.embeddingDimension, in: 256...AppSettings.maxEmbeddingDimension, step: 256) {
+                    HStack {
+                        Text("Embedding Dimensions")
+                        Spacer()
+                        Text("\(viewModel.embeddingDimension)")
+                            .foregroundStyle(.secondary)
+                    }
                 }
-            }
-            .onChange(of: viewModel.embeddingDimension) {
-                viewModel.saveEmbeddingDimension()
+                .onChange(of: viewModel.embeddingDimension) {
+                    viewModel.saveEmbeddingDimension()
+                }
             }
         } header: {
             Text("Knowledge Extraction")
         } footer: {
-            Text("Configure LLM for knowledge extraction and embedding model for semantic search. Changing the embedding dimension requires a knowledge graph reset.")
+            if viewModel.embeddingProvider == .nomic {
+                Text("Configure LLM for knowledge extraction. Nomic Embed Text v1.5 runs on-device via MLTensor (768-d vectors). Switching providers may require a knowledge graph reset.")
+            } else {
+                Text("Configure LLM for knowledge extraction and embedding model for semantic search. Changing the embedding dimension requires a knowledge graph reset.")
+            }
         }
     }
 

--- a/NewsCombAppTests/HypergraphServiceTests.swift
+++ b/NewsCombAppTests/HypergraphServiceTests.swift
@@ -127,22 +127,16 @@ final class HypergraphServiceTests: XCTestCase {
         XCTAssertNil(settings.ollamaModel)
         XCTAssertNil(settings.openRouterKey)
         XCTAssertNil(settings.openRouterModel)
-        XCTAssertEqual(settings.embeddingProvider, "ollama")
-        XCTAssertNil(settings.embeddingOllamaEndpoint)
-        XCTAssertNil(settings.embeddingOllamaModel)
+        XCTAssertEqual(settings.embeddingProvider, "nomic")
         XCTAssertNil(settings.embeddingOpenRouterModel)
     }
 
     func testLLMSettingsEmbeddingConfiguration() {
         var settings = LLMSettings()
         settings.embeddingProvider = "openrouter"
-        settings.embeddingOllamaEndpoint = "http://localhost:11435"
-        settings.embeddingOllamaModel = "mxbai-embed-large"
         settings.embeddingOpenRouterModel = "openai/text-embedding-3-large"
 
         XCTAssertEqual(settings.embeddingProvider, "openrouter")
-        XCTAssertEqual(settings.embeddingOllamaEndpoint, "http://localhost:11435")
-        XCTAssertEqual(settings.embeddingOllamaModel, "mxbai-embed-large")
         XCTAssertEqual(settings.embeddingOpenRouterModel, "openai/text-embedding-3-large")
     }
 
@@ -202,8 +196,6 @@ final class HypergraphServiceTests: XCTestCase {
 
     func testAppSettingsEmbeddingKeys() {
         XCTAssertEqual(AppSettings.embeddingProvider, "embedding_provider")
-        XCTAssertEqual(AppSettings.embeddingOllamaEndpoint, "embedding_ollama_endpoint")
-        XCTAssertEqual(AppSettings.embeddingOllamaModel, "embedding_ollama_model")
         XCTAssertEqual(AppSettings.embeddingOpenRouterModel, "embedding_openrouter_model")
     }
 
@@ -231,23 +223,23 @@ final class HypergraphServiceTests: XCTestCase {
     // MARK: - EmbeddingProviderOption Tests
 
     func testEmbeddingProviderOptionDisplayNames() {
-        XCTAssertEqual(EmbeddingProviderOption.ollama.displayName, "Ollama (Local)")
+        XCTAssertEqual(EmbeddingProviderOption.nomic.displayName, "Nomic (On-Device)")
         XCTAssertEqual(EmbeddingProviderOption.openrouter.displayName, "OpenRouter (Cloud)")
     }
 
     func testEmbeddingProviderOptionRawValues() {
-        XCTAssertEqual(EmbeddingProviderOption.ollama.rawValue, "ollama")
+        XCTAssertEqual(EmbeddingProviderOption.nomic.rawValue, "nomic")
         XCTAssertEqual(EmbeddingProviderOption.openrouter.rawValue, "openrouter")
     }
 
     func testEmbeddingProviderOptionAllCases() {
         XCTAssertEqual(EmbeddingProviderOption.allCases.count, 2)
-        XCTAssertTrue(EmbeddingProviderOption.allCases.contains(.ollama))
+        XCTAssertTrue(EmbeddingProviderOption.allCases.contains(.nomic))
         XCTAssertTrue(EmbeddingProviderOption.allCases.contains(.openrouter))
     }
 
     func testEmbeddingProviderOptionIdentifiable() {
-        XCTAssertEqual(EmbeddingProviderOption.ollama.id, "ollama")
+        XCTAssertEqual(EmbeddingProviderOption.nomic.id, "nomic")
         XCTAssertEqual(EmbeddingProviderOption.openrouter.id, "openrouter")
     }
 


### PR DESCRIPTION
## Summary
- Adds [swift-embeddings](https://github.com/jkrukowski/swift-embeddings) package dependency for on-device NomicBert embedding (`nomic-embed-text-v1.5`, 768-d vectors)
- Replaces the buggy Ollama embedding provider with Nomic as the default, keeping OpenRouter as an alternative
- Updates upstream dependencies: SwiftAgents and Conduit fork with widened swift-syntax constraint (`"600.0.0"..<"700.0.0"`) for Xcode 26.3+ compatibility

## Changes
- **NomicEmbeddingService** (new): wraps swift-embeddings NomicBert API with actor-based model caching
- **HypergraphService / GraphRAGService**: replaced Ollama embedding branches with `NomicEmbeddingService.shared.embed()`
- **AppSettings**: removed Ollama embedding settings, default provider → "nomic", dimension → 768
- **SettingsView**: Nomic shows read-only model info; OpenRouter keeps dimension stepper
- **DatabaseService**: removed Ollama embedding default seeds
- Transparent `"ollama" → "nomic"` migration in all three settings-loading locations

## Test plan
- [x] All 20 unit tests pass
- [x] Build succeeds with clean DerivedData (no local dependency patches needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)