### PR TITLE
Workspaces: multiple independent SQLite knowledge bases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,19 @@ This project uses [GRDB.swift](https://github.com/groue/GRDB.swift) for SQLite p
 
 ### Database access
 
-- Use a shared `Database` singleton for database access throughout the app.
-- Use `database.read { db in ... }` for read operations.
-- Use `database.write { db in ... }` for write operations.
+- Access the active workspace's database via `Database.current` — a workspace-aware accessor backed by `WorkspaceCoordinator`.
+- Do **not** reintroduce a `Database.shared` singleton. The active database can change at app launch (workspace switch via relaunch); call sites must read `Database.current` each time rather than capturing a reference.
+- Use `Database.current.read { db in ... }` for read operations.
+- Use `Database.current.write { db in ... }` for write operations.
 - Use GRDB's query interface for type-safe queries (e.g., `Model.filter(...).fetchAll(db)`).
 - Use raw SQL with parameterized arguments for complex upserts and joins.
+
+### Workspaces and settings scope
+
+- A **workspace** is a directory containing `newscomb.sqlite`. The user picks the active workspace via `--workspace` CLI arg / `NEWSCOMB_WORKSPACE` env / Settings UI / File menu.
+- **Workspace-scoped settings** live in the per-DB `app_settings` table (`AppSettings` model). New settings about LLM/embedding/RAG/feeds/themes go here. They differ across workspaces.
+- **App-global settings** live in `UserDefaults` via `WorkspaceDefaults`. Today only `lastOpenedWorkspace` and `recentWorkspaces` are global. Add new global settings only when they truly persist across workspaces (e.g., a global theme preference).
+- See `NewsCombApp/Services/WorkspaceCoordinator.swift` for the bootstrap and switch-workspace flow, and `WORKSPACE_PLAN.md` for the design rationale.
 
 
 ## Logging instructions

--- a/NewsComb/Sources/NewsCombApp.swift
+++ b/NewsComb/Sources/NewsCombApp.swift
@@ -7,8 +7,8 @@ import AppKit
 @main
 struct NewsCombApp: App {
     init() {
-        // Database is initialized lazily via Database.shared
-        _ = Database.shared
+        // Database is initialized lazily via Database.current
+        _ = Database.current
 
         #if canImport(AppKit)
         // Activate the app and bring it to front

--- a/NewsComb/Sources/Services/DatabaseService.swift
+++ b/NewsComb/Sources/Services/DatabaseService.swift
@@ -3,6 +3,7 @@ import GRDB
 
 public final class Database: Sendable {
     public static let shared = Database()
+    public static var current: Database { shared }
 
     let dbQueue: DatabaseQueue
 

--- a/NewsComb/Sources/Services/FeedbinExtractService.swift
+++ b/NewsComb/Sources/Services/FeedbinExtractService.swift
@@ -20,7 +20,7 @@ struct ExtractedContent: Decodable {
 }
 
 struct FeedbinExtractService {
-    private let database = Database.shared
+    private let database = Database.current
     private let baseURL = "https://extract.feedbin.com/parser"
 
     @concurrent

--- a/NewsComb/Sources/Services/RSSService.swift
+++ b/NewsComb/Sources/Services/RSSService.swift
@@ -21,7 +21,7 @@ struct FeedItemData {
 }
 
 struct RSSService {
-    private let database = Database.shared
+    private let database = Database.current
 
     @concurrent
     func fetchAllFeeds(sources: [RSSSource], extractService: FeedbinExtractService) async -> [FetchResult] {

--- a/NewsComb/Sources/ViewModels/MainViewModel.swift
+++ b/NewsComb/Sources/ViewModels/MainViewModel.swift
@@ -29,7 +29,7 @@ class MainViewModel {
     var totalItemsFetched = 0
     var errorMessage: String?
 
-    private let database = Database.shared
+    private let database = Database.current
 
     @ObservationIgnored
     private let rssService = RSSService()

--- a/NewsComb/Sources/ViewModels/SettingsViewModel.swift
+++ b/NewsComb/Sources/ViewModels/SettingsViewModel.swift
@@ -11,7 +11,7 @@ class SettingsViewModel {
     var openRouterKey: String = ""
     var errorMessage: String?
 
-    private let database = Database.shared
+    private let database = Database.current
 
     func loadData() {
         loadRSSSources()

--- a/NewsCombApp/MCP/MCPHTTPServer.swift
+++ b/NewsCombApp/MCP/MCPHTTPServer.swift
@@ -109,6 +109,20 @@ final class MCPHTTPServer: Sendable {
 
     private func dispatchRequest(_ request: MCP.HTTPRequest, on connection: NWConnection) {
         Task {
+            // Workspace-header check — reject mismatched bridges with a JSON-RPC error.
+            if let failure = await self.validateWorkspaceHeader(request) {
+                logger.warning("Workspace header validation failed: \(failure.message, privacy: .public)")
+                let httpData = Self.makeJSONRPCErrorHTTPResponse(
+                    requestId: Self.extractRequestId(from: request.body),
+                    code: failure.code,
+                    message: failure.message
+                )
+                connection.send(content: httpData, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+                return
+            }
+
             let (transport, sessionId) = await self.resolveTransport(for: request)
             let response = await transport.handleRequest(request)
             let httpData = self.formatHTTPResponse(response, sessionId: sessionId)
@@ -116,6 +130,44 @@ final class MCPHTTPServer: Sendable {
                 connection.cancel()
             })
         }
+    }
+
+    private func validateWorkspaceHeader(_ request: MCP.HTTPRequest) async -> MCPWorkspaceValidator.ValidationFailure? {
+        let active = await MainActor.run { WorkspaceCoordinator.shared.active?.directory }
+        return MCPWorkspaceValidator.validate(
+            requestedHeader: request.header(MCPWorkspaceValidator.headerName),
+            active: active
+        )
+    }
+
+    /// Constructs an HTTP/1.1 400 response with a JSON-RPC error body.
+    static func makeJSONRPCErrorHTTPResponse(requestId: String?, code: Int, message: String) -> Data {
+        let escapedMessage = message.replacing("\\", with: "\\\\").replacing("\"", with: "\\\"")
+        let idJSON = requestId.map { "\"\($0)\"" } ?? "null"
+        let body = Data("""
+            {"jsonrpc":"2.0","id":\(idJSON),"error":{"code":\(code),"message":"\(escapedMessage)"}}
+            """.utf8)
+
+        var result = "HTTP/1.1 400 Bad Request\r\n"
+        result += "Content-Type: application/json\r\n"
+        result += "Content-Length: \(body.count)\r\n"
+        result += "Connection: close\r\n"
+        result += "\r\n"
+
+        var data = Data(result.utf8)
+        data.append(body)
+        return data
+    }
+
+    /// Extracts the JSON-RPC `id` from a request body (string or integer).
+    static func extractRequestId(from body: Data?) -> String? {
+        guard let body,
+              let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+            return nil
+        }
+        if let id = json["id"] as? String { return id }
+        if let id = json["id"] as? Int { return String(id) }
+        return nil
     }
 
     // MARK: - Session Management

--- a/NewsCombApp/MCP/MCPToolDispatcher.swift
+++ b/NewsCombApp/MCP/MCPToolDispatcher.swift
@@ -3,7 +3,7 @@ import MCP
 import OSLog
 
 /// Dispatches MCP tool calls to the appropriate handler.
-/// All tools use the app's existing services via `Database.shared`.
+/// All tools use the app's existing services via `Database.current`.
 enum MCPToolDispatcher {
 
     private static let logger = Logger(subsystem: "com.newscomb.app", category: "MCPTools")

--- a/NewsCombApp/MCP/MCPToolHandler.swift
+++ b/NewsCombApp/MCP/MCPToolHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 import MCP
 
 /// Registers all NewsComb MCP tools and dispatches tool calls.
-/// Uses the app's `Database.shared` directly — no separate database wrapper needed.
+/// Uses the app's `Database.current` directly — no separate database wrapper needed.
 struct MCPToolHandler: Sendable {
 
     /// All available tools with their JSON Schema definitions.

--- a/NewsCombApp/MCP/MCPWorkspaceValidator.swift
+++ b/NewsCombApp/MCP/MCPWorkspaceValidator.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Validates an MCP request's `X-Workspace` header against the app's active
+/// workspace. Pure value-level logic — no I/O, no dependencies — so it can be
+/// unit-tested without standing up the HTTP server or the coordinator.
+///
+/// Backward compatibility: if the bridge does not send the header (older
+/// versions, manual curl calls), validation passes. Only requests that
+/// explicitly assert a workspace are checked.
+enum MCPWorkspaceValidator {
+
+    static let headerName = "X-Workspace"
+
+    enum ValidationFailure: Equatable, Sendable {
+        case noActiveWorkspace(requested: URL)
+        case mismatch(active: URL, requested: URL)
+
+        var message: String {
+            switch self {
+            case .noActiveWorkspace(let requested):
+                return "NewsComb has no active workspace. The bridge requested '\(requested.path(percentEncoded: false))'. Open this workspace in the NewsComb app first."
+            case .mismatch(let active, let requested):
+                return "Workspace mismatch: app is on '\(active.path(percentEncoded: false))', bridge requested '\(requested.path(percentEncoded: false))'. Open the matching workspace via File → Open Workspace in NewsComb, or update the bridge's --workspace argument."
+            }
+        }
+
+        /// JSON-RPC error code (server-defined range -32000…-32099).
+        var code: Int { -32001 }
+    }
+
+    /// Returns `nil` to allow the request, or a `ValidationFailure` describing why
+    /// the request should be rejected.
+    static func validate(
+        requestedHeader: String?,
+        active: URL?
+    ) -> ValidationFailure? {
+        guard let requestedPath = requestedHeader, !requestedPath.isEmpty else {
+            return nil
+        }
+        let requested = URL(filePath: requestedPath).canonicalDirectoryURL
+        guard let active else {
+            return .noActiveWorkspace(requested: requested)
+        }
+        if active == requested { return nil }
+        return .mismatch(active: active, requested: requested)
+    }
+}

--- a/NewsCombApp/MCP/Tools/MCPCompareThemesTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPCompareThemesTool.swift
@@ -10,7 +10,7 @@ import MCP
 /// Useful for spotting near-duplicate clusters, related sub-themes, or unexpectedly
 /// connected topics that the labeling LLM may have missed.
 enum MCPCompareThemesTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let idsValue = arguments["cluster_ids"] else {
             throw MCPToolError.missingParameter("cluster_ids")
         }

--- a/NewsCombApp/MCP/Tools/MCPFindArticlesAcrossThemesTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPFindArticlesAcrossThemesTool.swift
@@ -6,7 +6,7 @@ import MCP
 /// Surfaces articles that bridge separate stories — useful for editorial analysis,
 /// trend correlation, and finding "hub" articles that touch many narratives.
 enum MCPFindArticlesAcrossThemesTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         let minThemes = arguments["min_themes"]?.intValue ?? 2
         let limit = arguments["limit"]?.intValue ?? 20
 

--- a/NewsCombApp/MCP/Tools/MCPFindPathsTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPFindPathsTool.swift
@@ -6,7 +6,7 @@ import MCP
 /// Finds multi-hop reasoning paths between two concepts using BFS.
 /// Reuses the app's `HypergraphPathService` for the actual BFS traversal.
 enum MCPFindPathsTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let source = arguments["source"]?.stringValue, !source.isEmpty else {
             throw MCPToolError.missingParameter("source")
         }

--- a/NewsCombApp/MCP/Tools/MCPGetEntityThemesTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetEntityThemesTool.swift
@@ -6,7 +6,7 @@ import MCP
 /// edges fall into each theme. Answers questions like "which story themes is OpenAI
 /// involved in, and which is the most prominent?"
 enum MCPGetEntityThemesTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let entityLabel = arguments["entity_label"]?.stringValue, !entityLabel.isEmpty else {
             throw MCPToolError.missingParameter("entity_label")
         }

--- a/NewsCombApp/MCP/Tools/MCPGetNodeNeighborsTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetNodeNeighborsTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Gets all edges (relationships) connected to a node, showing neighbors and provenance.
 enum MCPGetNodeNeighborsTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let nodeLabel = arguments["node_label"]?.stringValue, !nodeLabel.isEmpty else {
             throw MCPToolError.missingParameter("node_label")
         }

--- a/NewsCombApp/MCP/Tools/MCPGetRecentArticlesTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetRecentArticlesTool.swift
@@ -10,7 +10,7 @@ enum MCPGetRecentArticlesTool {
         formatter.timeStyle = .short
         return formatter
     }()
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         let limit = arguments["limit"]?.intValue ?? 20
         let sourceFilter = arguments["source"]?.stringValue
 

--- a/NewsCombApp/MCP/Tools/MCPGetStatisticsTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetStatisticsTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Returns knowledge graph statistics.
 enum MCPGetStatisticsTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         try database.read { db in
             let nodeCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM hypergraph_node") ?? 0
             let edgeCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM hypergraph_edge") ?? 0

--- a/NewsCombApp/MCP/Tools/MCPGetThemeDetailsTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetThemeDetailsTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Gets detailed information about a specific theme cluster.
 enum MCPGetThemeDetailsTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let clusterId = arguments["cluster_id"]?.intValue else {
             throw MCPToolError.missingParameter("cluster_id")
         }

--- a/NewsCombApp/MCP/Tools/MCPGetThemeProvenanceTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetThemeProvenanceTool.swift
@@ -8,7 +8,7 @@ import MCP
 ///
 /// Complements `get_theme_details`, which only shows the top-10 exemplars.
 enum MCPGetThemeProvenanceTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let clusterId = arguments["cluster_id"]?.intValue else {
             throw MCPToolError.missingParameter("cluster_id")
         }

--- a/NewsCombApp/MCP/Tools/MCPGetThemesTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPGetThemesTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Lists story theme clusters with labels, sizes, top entities, and summaries.
 enum MCPGetThemesTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         let limit = arguments["limit"]?.intValue ?? 20
         let query = arguments["query"]?.stringValue
 

--- a/NewsCombApp/MCP/Tools/MCPQueryKnowledgeGraphTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPQueryKnowledgeGraphTool.swift
@@ -8,13 +8,13 @@ import MCP
 /// Uses the app's existing services directly:
 /// - `NomicEmbeddingService.shared` for on-device embeddings
 /// - `HypergraphPathService` for BFS path finding
-/// - `Database.shared` for all queries
+/// - `Database.current` for all queries
 /// - `ContextCollector.extractRelation(from:)` for edge label extraction
 ///
 /// Returns assembled context for the MCP client to synthesize — does NOT generate an LLM answer.
 enum MCPQueryKnowledgeGraphTool {
 
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) async throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) async throws -> String {
         guard let question = arguments["question"]?.stringValue, !question.isEmpty else {
             throw MCPToolError.missingParameter("question")
         }

--- a/NewsCombApp/MCP/Tools/MCPSearchChunksTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPSearchChunksTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Searches article text chunks using FTS5.
 enum MCPSearchChunksTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let query = arguments["query"]?.stringValue, !query.isEmpty else {
             throw MCPToolError.missingParameter("query")
         }

--- a/NewsCombApp/MCP/Tools/MCPSearchConceptsTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPSearchConceptsTool.swift
@@ -4,7 +4,7 @@ import MCP
 
 /// Searches for entities/concepts in the knowledge graph using FTS5.
 enum MCPSearchConceptsTool {
-    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.shared) throws -> String {
+    static func run(arguments: [String: Value], database: any MCPDatabaseReader = Database.current) throws -> String {
         guard let query = arguments["query"]?.stringValue, !query.isEmpty else {
             throw MCPToolError.missingParameter("query")
         }

--- a/NewsCombApp/Models/AppSettings.swift
+++ b/NewsCombApp/Models/AppSettings.swift
@@ -47,6 +47,13 @@ extension AppSettings {
     /// Used to detect when tables need to be recreated after a dimension change.
     static let activeEmbeddingDimension = "active_embedding_dimension"
 
+    /// When set to "1", suppresses the default-RSS-feed seeding logic in
+    /// `Database.seedDefaultRSSSources`. Used by
+    /// `WorkspaceCoordinator.provisionNewWorkspace` to keep a freshly-created
+    /// workspace empty of feeds — the user picks feeds appropriate to the
+    /// new domain rather than inheriting the curated tech list.
+    static let feedSeedSuppressed = "feed_seed_suppressed"
+
     /// Returns the effective embedding dimension for the currently active provider.
     ///
     /// Nomic Embed Text v1.5 always produces 768-d vectors regardless of the

--- a/NewsCombApp/Models/Workspace.swift
+++ b/NewsCombApp/Models/Workspace.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// A NewsComb workspace — a directory on disk containing a `newscomb.sqlite`
+/// database and any associated artifacts. Identified by the canonicalized
+/// directory URL.
+///
+/// Pure value type, no I/O. Validation (does the directory exist? is it
+/// writable? does it contain a valid DB?) is the coordinator's job.
+struct Workspace: Identifiable, Equatable, Hashable, Sendable {
+
+    static let databaseFileName = "newscomb.sqlite"
+
+    /// Canonicalized directory containing this workspace's database.
+    let directory: URL
+
+    var id: URL { directory }
+
+    /// Display name — the directory's last path component (e.g. `"Tech"`).
+    var name: String { directory.lastPathComponent }
+
+    /// Absolute path to the workspace's SQLite file.
+    var databaseFileURL: URL {
+        directory.appending(path: Workspace.databaseFileName)
+    }
+
+    init(directory: URL) {
+        self.directory = directory.canonicalDirectoryURL
+    }
+}
+
+extension URL {
+
+    /// Canonicalizes a file URL representing a directory: standardizes (resolves
+    /// `.` / `..`) and strips the trailing `/` so equality holds across the
+    /// variants `/tmp/Foo` and `/tmp/Foo/`.
+    var canonicalDirectoryURL: URL {
+        let std = self.standardizedFileURL
+        let path = std.path(percentEncoded: false)
+        guard path.hasSuffix("/"), path != "/" else { return std }
+        return URL(filePath: String(path.dropLast()))
+    }
+}
+
+extension Workspace {
+
+    /// Default location for newly-created workspaces:
+    /// `~/Documents/NewsComb-Workspaces/`.
+    static var defaultWorkspacesRoot: URL {
+        URL.documentsDirectory.appending(path: "NewsComb-Workspaces")
+    }
+
+    /// Legacy single-DB location used before the workspace feature.
+    /// `~/Library/Application Support/NewsComb/` containing `newscomb.sqlite`.
+    /// Treated as the "Default" workspace on first launch after upgrade.
+    static var legacyDirectory: URL {
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appending(path: "NewsComb")
+    }
+
+    static var legacyWorkspace: Workspace {
+        Workspace(directory: legacyDirectory)
+    }
+}

--- a/NewsCombApp/NewsCombApp.swift
+++ b/NewsCombApp/NewsCombApp.swift
@@ -16,15 +16,9 @@ struct NewsCombApp: App {
             case .opened(let workspace, let source):
                 logger.notice("Bootstrapped workspace '\(workspace.name, privacy: .public)' from \(String(describing: source), privacy: .public)")
             case .needsSelection:
-                // No workspace configured yet. The first-run picker (Phase 6 UI)
-                // will handle this; for now Database.current's lazy fallback
-                // keeps the app functional.
-                logger.notice("No workspace configured at launch; awaiting first-run selection")
+                logger.notice("No workspace configured at launch; ContentView will show first-run picker")
             }
         } catch {
-            // Explicit source (--workspace arg or env var) failed to open.
-            // Phase 6 will surface this via an error sheet; for now log + fall
-            // through to the lazy bootstrap.
             logger.error("Workspace bootstrap failed: \(error.localizedDescription, privacy: .public)")
         }
 
@@ -37,6 +31,11 @@ struct NewsCombApp: App {
         WindowGroup {
             ContentView()
         }
+        #if os(macOS)
+        .commands {
+            WorkspaceCommands(coordinator: WorkspaceCoordinator.shared)
+        }
+        #endif
 
         #if os(macOS)
         Settings {

--- a/NewsCombApp/NewsCombApp.swift
+++ b/NewsCombApp/NewsCombApp.swift
@@ -1,10 +1,32 @@
+import OSLog
 import SwiftUI
 
 @main
 struct NewsCombApp: App {
+
     init() {
-        // Database is initialized lazily via Database.current
-        _ = Database.current
+        let logger = Logger(subsystem: "com.newscomb.app", category: "Launch")
+
+        // Resolve the active workspace before any code reads Database.current.
+        // Resolution order: --workspace arg > NEWSCOMB_WORKSPACE env >
+        // last-opened (UserDefaults) > legacy ~/Library/Application Support DB.
+        do {
+            let result = try WorkspaceCoordinator.shared.bootstrap()
+            switch result {
+            case .opened(let workspace, let source):
+                logger.notice("Bootstrapped workspace '\(workspace.name, privacy: .public)' from \(String(describing: source), privacy: .public)")
+            case .needsSelection:
+                // No workspace configured yet. The first-run picker (Phase 6 UI)
+                // will handle this; for now Database.current's lazy fallback
+                // keeps the app functional.
+                logger.notice("No workspace configured at launch; awaiting first-run selection")
+            }
+        } catch {
+            // Explicit source (--workspace arg or env var) failed to open.
+            // Phase 6 will surface this via an error sheet; for now log + fall
+            // through to the lazy bootstrap.
+            logger.error("Workspace bootstrap failed: \(error.localizedDescription, privacy: .public)")
+        }
 
         // Start the MCP stdio server on a background task.
         // AI assistants (Claude Code, Claude Desktop) can connect via stdio transport.

--- a/NewsCombApp/NewsCombApp.swift
+++ b/NewsCombApp/NewsCombApp.swift
@@ -3,8 +3,8 @@ import SwiftUI
 @main
 struct NewsCombApp: App {
     init() {
-        // Database is initialized lazily via Database.shared
-        _ = Database.shared
+        // Database is initialized lazily via Database.current
+        _ = Database.current
 
         // Start the MCP stdio server on a background task.
         // AI assistants (Claude Code, Claude Desktop) can connect via stdio transport.

--- a/NewsCombApp/Services/ClusterLabelingService.swift
+++ b/NewsCombApp/Services/ClusterLabelingService.swift
@@ -16,7 +16,7 @@ final class ClusterLabelingService: Sendable {
     /// Progress update with fraction complete (0..1).
     typealias ProgressCallback = @MainActor @Sendable (Double) -> Void
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "ClusterLabelingService")
 
     // MARK: - System Prompt

--- a/NewsCombApp/Services/ClusteringService.swift
+++ b/NewsCombApp/Services/ClusteringService.swift
@@ -18,7 +18,7 @@ final class ClusteringService: Sendable {
     /// Progress update with fraction complete (0..1).
     typealias ProgressCallback = @MainActor @Sendable (Double) -> Void
 
-    private let database = Database.shared
+    private let database = Database.current
     private let eventVectorService = EventVectorService()
     private let pcaService = PCAService()
     private let umapService = UMAPService()

--- a/NewsCombApp/Services/DatabaseService.swift
+++ b/NewsCombApp/Services/DatabaseService.swift
@@ -769,8 +769,19 @@ public final class Database: Sendable {
     }
 
     /// Seeds default RSS sources into the database.
-    /// Only seeds if no sources exist yet (first app launch).
+    /// Only seeds if no sources exist yet (first app launch) AND the
+    /// `feed_seed_suppressed` flag isn't set (workspace explicitly provisioned
+    /// empty).
     private func seedDefaultRSSSources(_ db: GRDB.Database) throws {
+        // Honor explicit opt-out — set by `WorkspaceCoordinator.provisionNewWorkspace`.
+        let isSuppressed = try AppSettings
+            .filter(AppSettings.Columns.key == AppSettings.feedSeedSuppressed)
+            .fetchOne(db) != nil
+        if isSuppressed {
+            Self.logger.info("RSS feed seeding suppressed for this workspace")
+            return
+        }
+
         // Check if any sources already exist
         let sourceCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
         guard sourceCount == 0 else {

--- a/NewsCombApp/Services/DatabaseService.swift
+++ b/NewsCombApp/Services/DatabaseService.swift
@@ -2,36 +2,69 @@ import Foundation
 import GRDB
 import OSLog
 import SQLiteExtensions
+import Synchronization
 
 public final class Database: Sendable {
     private static let logger = Logger(subsystem: "com.newscomb", category: "Database")
-    public static let shared = Database()
+
+    /// Workspace directory containing this database's `newscomb.sqlite` file.
+    public let workspaceDirectory: URL
 
     let dbQueue: DatabaseQueue
 
-    private init() {
-        do {
+    /// Backing storage for the active workspace's database. Mutated via
+    /// `setCurrent(_:)` (called by `WorkspaceCoordinator` during bootstrap and
+    /// workspace switch). Read via `Database.current`.
+    private static let active = Mutex<Database?>(nil)
 
-            // Initialize all SQLite extensions
-            SQLiteExtensions.initialize_sqlite3_extensions()
-
-            let fileManager = FileManager.default
-            let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            let dbDirectory = appSupport.appending(path: "NewsComb")
-
-            try fileManager.createDirectory(at: dbDirectory, withIntermediateDirectories: true)
-
-            let dbPath = dbDirectory.appending(path: "newscomb.sqlite")
-            Self.logger.info("Database path: open '\(dbPath.path(percentEncoded: false), privacy: .public)'")
-
-            var config = Configuration()
-            config.foreignKeysEnabled = true
-            dbQueue = try DatabaseQueue(path: dbPath.path, configuration: config)
-
-            try migrate()
-        } catch {
-            fatalError("Failed to initialize database: \(error)")
+    /// The database for the currently-active workspace.
+    ///
+    /// During the workspace-feature transition, this lazy-bootstraps to the
+    /// legacy directory (`~/Library/Application Support/NewsComb/`) if no active
+    /// workspace has been set yet. Phase 3 will set the active workspace
+    /// explicitly at app launch, making the fallback dead code.
+    public static var current: Database {
+        active.withLock { holder in
+            if let db = holder { return db }
+            do {
+                let db = try Database(directory: Workspace.legacyDirectory)
+                holder = db
+                return db
+            } catch {
+                fatalError("Failed to lazy-bootstrap legacy database: \(error)")
+            }
         }
+    }
+
+    /// Sets the active workspace's database. Called by `WorkspaceCoordinator`.
+    public static func setCurrent(_ database: Database) {
+        active.withLock { $0 = database }
+    }
+
+    /// Test-only: clears the active database so the next `current` access
+    /// re-bootstraps. Production code should use `setCurrent(_:)`.
+    static func resetCurrentForTesting() {
+        active.withLock { $0 = nil }
+    }
+
+    /// Opens (or creates) a database at `<directory>/newscomb.sqlite`,
+    /// running migrations and seeding defaults.
+    public init(directory: URL) throws {
+        // Initialize all SQLite extensions (idempotent — safe to call again on workspace switch)
+        SQLiteExtensions.initialize_sqlite3_extensions()
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let dbPath = directory.appending(path: Workspace.databaseFileName)
+        Self.logger.info("Database path: open '\(dbPath.path(percentEncoded: false), privacy: .public)'")
+
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+
+        self.workspaceDirectory = directory.canonicalDirectoryURL
+        self.dbQueue = try DatabaseQueue(path: dbPath.path(percentEncoded: false), configuration: config)
+
+        try migrate()
     }
 
     private func migrate() throws {

--- a/NewsCombApp/Services/DeepAnalysisService.swift
+++ b/NewsCombApp/Services/DeepAnalysisService.swift
@@ -14,7 +14,7 @@ import OSLog
 /// The agents work sequentially, with each building on the previous output.
 final class DeepAnalysisService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "DeepAnalysisService")
 
     // MARK: - Callbacks

--- a/NewsCombApp/Services/EventVectorService.swift
+++ b/NewsCombApp/Services/EventVectorService.swift
@@ -17,7 +17,7 @@ final class EventVectorService: Sendable {
     /// Total dimension of the final event vector: `3 * embeddingDim + RelationFamily.count`.
     let eventVecDim: Int
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "EventVectorService")
 
     init() {
@@ -29,7 +29,7 @@ final class EventVectorService: Sendable {
     /// Reads the effective embedding dimension for the active provider.
     private static func loadEmbeddingDimension() -> Int {
         do {
-            return try Database.shared.read { db in
+            return try Database.current.read { db in
                 return try AppSettings.effectiveEmbeddingDimension(db)
             }
         } catch {

--- a/NewsCombApp/Services/GraphDataService.swift
+++ b/NewsCombApp/Services/GraphDataService.swift
@@ -29,7 +29,7 @@ struct GraphData {
 /// Service for loading graph data from the database.
 final class GraphDataService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
 
     /// Load the complete hypergraph from the database.
     func loadFullGraph() throws -> GraphData {

--- a/NewsCombApp/Services/GraphRAGService.swift
+++ b/NewsCombApp/Services/GraphRAGService.swift
@@ -6,7 +6,7 @@ import OSLog
 /// Service for querying the knowledge graph using RAG (Retrieval-Augmented Generation).
 final class GraphRAGService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "GraphRAGService")
 
     /// Callback fired with a human-readable status string at each pipeline phase.

--- a/NewsCombApp/Services/HypergraphPathService.swift
+++ b/NewsCombApp/Services/HypergraphPathService.swift
@@ -6,7 +6,7 @@ import OSLog
 /// Implements the path-finding algorithm from the Python GraphReasoning library.
 final class HypergraphPathService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "HypergraphPathService")
 
     // MARK: - Types

--- a/NewsCombApp/Services/HypergraphService.swift
+++ b/NewsCombApp/Services/HypergraphService.swift
@@ -6,7 +6,7 @@ import OSLog
 /// Service for extracting and persisting hypergraph knowledge from articles.
 final class HypergraphService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "HypergraphService")
 
     // Cancellation support (accessed only from @MainActor methods)

--- a/NewsCombApp/Services/KeywordExtractionService.swift
+++ b/NewsCombApp/Services/KeywordExtractionService.swift
@@ -19,7 +19,7 @@ enum KeywordExtractionService {
     /// Falls back to rule-based extraction if the LLM is unavailable or fails.
     static func extractKeywords(
         from question: String,
-        database: any MCPDatabaseReader = Database.shared
+        database: any MCPDatabaseReader = Database.current
     ) async -> [String] {
         do {
             let settings = try loadSettings(database: database)

--- a/NewsCombApp/Services/NodeMergingService.swift
+++ b/NewsCombApp/Services/NodeMergingService.swift
@@ -12,7 +12,7 @@ struct MergeResult: Sendable {
 /// Service for merging similar nodes in the hypergraph based on embedding similarity.
 final class NodeMergingService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "NodeMergingService")
 
     /// Default similarity threshold for merging (0.9 = 90% similar).

--- a/NewsCombApp/Services/QueryHistoryService.swift
+++ b/NewsCombApp/Services/QueryHistoryService.swift
@@ -4,7 +4,7 @@ import OSLog
 
 /// Service for managing query history persistence.
 struct QueryHistoryService {
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "QueryHistoryService")
 
     /// Saves a GraphRAGResponse to the query history.

--- a/NewsCombApp/Services/RSSService.swift
+++ b/NewsCombApp/Services/RSSService.swift
@@ -13,7 +13,7 @@ struct FetchResult: Sendable {
 }
 
 struct RSSService {
-    private let database = Database.shared
+    private let database = Database.current
 
     /// Returns the article age limit in days from settings, or the default value.
     private func getArticleAgeLimitDays() -> Int {

--- a/NewsCombApp/Services/UserRoleService.swift
+++ b/NewsCombApp/Services/UserRoleService.swift
@@ -4,7 +4,7 @@ import OSLog
 
 /// Service for managing user roles (personas with prompts).
 struct UserRoleService {
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "UserRoleService")
 
     // MARK: - CRUD Operations

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -178,32 +178,49 @@ final class WorkspaceCoordinator {
 
     // MARK: - Settings copy
 
-    /// Copies every row in the source workspace's `app_settings` table into
-    /// the target workspace's `app_settings` table (UPSERT by key). Used when
-    /// the user creates a new workspace and wants their LLM keys, model
-    /// selections, prompts, and algorithm parameters carried over instead of
-    /// reset to defaults.
+    /// Setting keys that describe **schema state on disk** rather than user
+    /// intent. These must NOT be copied between workspaces — copying them
+    /// would lie about the target's actual schema, breaking dimension-change
+    /// detection in `Database.migrate`.
+    ///
+    /// Currently just `active_embedding_dimension`, which records the dim the
+    /// vec0 virtual tables were last created with. Copying it would cause
+    /// `createVec0Tables` to think no rebuild is needed even when the
+    /// `embedding_dimension` setting was carried over from a workspace using
+    /// a different size. Leaving it untouched lets the next migration detect
+    /// the mismatch and rebuild the vec0 tables to match the user's intent.
+    private static let nonPortableSettingKeys: Set<String> = [
+        AppSettings.activeEmbeddingDimension
+    ]
+
+    /// Copies every portable row in the source workspace's `app_settings`
+    /// table into the target workspace's `app_settings` table (UPSERT by key).
+    /// Used when the user creates a new workspace and wants their LLM keys,
+    /// model selections, prompts, and algorithm parameters carried over
+    /// instead of reset to defaults.
     ///
     /// Both databases are opened transiently; `Database.current` is unchanged.
     /// The target's migration runs (creating tables and seeding defaults)
     /// before the upsert, so any new defaults the source's DB doesn't know
     /// about are preserved.
     ///
-    /// **Note**: a copied `embedding_dimension` setting can mismatch the
-    /// target's vec0 tables (which were created at the seed-default
-    /// dimension). Since a brand-new workspace has no embeddings yet, the
-    /// existing dimension-mismatch reset flow will rebuild the vec0 tables
-    /// at the right size on first use.
+    /// Schema-state keys (see `nonPortableSettingKeys`) are skipped so the
+    /// target's existing vec0-table dimension tracking remains accurate.
+    /// On first use, if the copied `embedding_dimension` differs from the
+    /// target's seed-default, `Database.migrate` detects the mismatch and
+    /// rebuilds the vec0 tables — putting settings and schema in agreement.
     func copyAppSettings(from source: URL, to target: URL) throws {
         let sourceDB = try Database(directory: source)
         let targetDB = try Database(directory: target)
 
-        let rows = try sourceDB.dbQueue.read { db in
+        let allRows = try sourceDB.dbQueue.read { db in
             try AppSettings.fetchAll(db)
         }
+        let portable = allRows.filter { !Self.nonPortableSettingKeys.contains($0.key) }
+        let skipped = allRows.count - portable.count
 
         try targetDB.dbQueue.write { db in
-            for setting in rows {
+            for setting in portable {
                 try db.execute(
                     sql: """
                         INSERT INTO app_settings (key, value) VALUES (?, ?)
@@ -215,7 +232,7 @@ final class WorkspaceCoordinator {
         }
 
         logger.notice(
-            "Copied \(rows.count, privacy: .public) app_settings rows from \(source.path(percentEncoded: false), privacy: .public) to \(target.path(percentEncoded: false), privacy: .public)"
+            "Copied \(portable.count, privacy: .public) app_settings rows (skipped \(skipped, privacy: .public) non-portable) from \(source.path(percentEncoded: false), privacy: .public) to \(target.path(percentEncoded: false), privacy: .public)"
         )
     }
 

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -248,6 +248,53 @@ final class WorkspaceCoordinator {
         return true
     }
 
+    /// Provisions a new workspace from the currently-active one for the
+    /// **File → New Workspace…** flow:
+    ///
+    /// 1. Copies portable app settings from the active workspace (LLM keys,
+    ///    model selections, prompts, algorithm parameters).
+    /// 2. Sets `feed_seed_suppressed = "1"` in the new workspace so future
+    ///    migrations don't re-seed the curated default RSS feeds.
+    /// 3. Deletes the seeded RSS feeds the migration just inserted.
+    ///
+    /// The user picks feeds appropriate to the new workspace's domain rather
+    /// than inheriting the source workspace's feeds OR the seed defaults.
+    ///
+    /// Returns `true` if provisioning happened, `false` if there was no
+    /// active workspace or `target` already equals the active workspace.
+    @discardableResult
+    func provisionNewWorkspace(at target: URL) throws -> Bool {
+        guard let active else { return false }
+        let canonicalTarget = target.canonicalDirectoryURL
+        guard active.directory != canonicalTarget else { return false }
+
+        // Step 1: copy portable settings (this also runs migrate on target,
+        // which seeds defaults including the curated RSS feed list).
+        try copyAppSettings(from: active.directory, to: canonicalTarget)
+
+        // Steps 2 & 3: in a single write, suppress future seeding and clear
+        // the seeded rows. Doing both in one transaction guarantees a consistent
+        // post-state — either the workspace is "provisioned empty" or unchanged.
+        let targetDB = try Database(directory: canonicalTarget)
+        let removed = try targetDB.dbQueue.write { db -> Int in
+            try db.execute(
+                sql: """
+                    INSERT INTO app_settings (key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                arguments: [AppSettings.feedSeedSuppressed, "1"]
+            )
+            let before = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+            try db.execute(sql: "DELETE FROM rss_source")
+            return before
+        }
+
+        logger.notice(
+            "Provisioned new workspace at \(canonicalTarget.path(percentEncoded: false), privacy: .public): copied settings, suppressed feed seeding, removed \(removed, privacy: .public) seeded feeds"
+        )
+        return true
+    }
+
     // MARK: - Switching
 
     enum SwitchError: Error, LocalizedError, Equatable {

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -28,9 +28,40 @@ final class WorkspaceCoordinator {
 
     private let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceCoordinator")
     private let defaults: WorkspaceDefaults
+    private let busyReasonsProvider: @MainActor () -> [String]
 
-    init(defaults: WorkspaceDefaults = .shared) {
+    init(
+        defaults: WorkspaceDefaults = .shared,
+        busyReasonsProvider: @escaping @MainActor () -> [String] = WorkspaceCoordinator.defaultBusyReasons
+    ) {
         self.defaults = defaults
+        self.busyReasonsProvider = busyReasonsProvider
+    }
+
+    /// Reasons the app currently can't accept a workspace switch. Empty when safe.
+    /// Reads observed VM state — SwiftUI views observing this re-render when
+    /// the underlying flags change.
+    var busyReasons: [String] {
+        busyReasonsProvider()
+    }
+
+    var canSwitchWorkspace: Bool {
+        busyReasons.isEmpty
+    }
+
+    /// Production busy-reasons provider. Inspects shared view models for
+    /// in-flight long-running operations.
+    @MainActor
+    static func defaultBusyReasons() -> [String] {
+        var reasons: [String] = []
+        let main = MainViewModel.shared
+        if main.isProcessingHypergraph { reasons.append("processing knowledge graph") }
+        if main.isRefreshing { reasons.append("refreshing feeds") }
+        if main.isImportingOPML { reasons.append("importing OPML") }
+        if main.isResettingGraph { reasons.append("resetting knowledge graph") }
+        if main.isSimplifyingGraph { reasons.append("simplifying graph") }
+        if main.isClassifying { reasons.append("classifying nodes") }
+        return reasons
     }
 
     /// Opens (or creates) the workspace rooted at `directory`: builds the
@@ -129,6 +160,41 @@ final class WorkspaceCoordinator {
 
         // 5. Nothing found — UI must show a first-run picker
         return .needsSelection
+    }
+
+    // MARK: - Switching
+
+    enum SwitchError: Error, LocalizedError, Equatable {
+        case busy(reasons: [String])
+
+        var errorDescription: String? {
+            switch self {
+            case .busy(let reasons):
+                return "Cannot switch workspace while busy: " + reasons.joined(separator: ", ")
+            }
+        }
+    }
+
+    /// Validates that no long-running jobs are in flight, then persists the
+    /// target directory as the last-opened workspace (so a relaunch resolves it
+    /// via Phase 3's bootstrap flow).
+    ///
+    /// **Does not relaunch the app** — that's the caller's responsibility. For
+    /// v1, the File-menu / Settings UI relaunches via `NSApplication`. This
+    /// keeps the coordinator decoupled from AppKit and gives every workspace a
+    /// fresh process state without complex tear-down inside the running app.
+    @discardableResult
+    func switchWorkspace(to directory: URL) throws -> Workspace {
+        let reasons = busyReasons
+        if !reasons.isEmpty {
+            logger.notice("Switch refused — busy: \(reasons.joined(separator: ", "), privacy: .public)")
+            throw SwitchError.busy(reasons: reasons)
+        }
+        let target = Workspace(directory: directory)
+        defaults.lastOpenedWorkspace = target.directory
+        defaults.pushRecent(target.directory)
+        logger.notice("Switch staged to '\(target.directory.path(percentEncoded: false), privacy: .public)' — caller must relaunch")
+        return target
     }
 
     /// Extracts `<path>` from `--workspace <path>` or `--workspace=<path>`.

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -55,4 +55,98 @@ final class WorkspaceCoordinator {
         defaults.pushRecent(workspace.directory)
         logger.notice("Active workspace: \(workspace.directory.path(percentEncoded: false), privacy: .public)")
     }
+
+    // MARK: - Bootstrap
+
+    /// Where the bootstrapped workspace came from. Useful for diagnostics + UI
+    /// (e.g. surfacing "opened from --workspace flag" in the about dialog).
+    enum BootstrapSource: Equatable, Sendable {
+        case commandLine(URL)
+        case environment(URL)
+        case lastOpened(URL)
+        case legacy(URL)
+    }
+
+    enum BootstrapResult: Sendable {
+        case opened(Workspace, source: BootstrapSource)
+        /// No workspace could be found; the UI should show a first-run picker.
+        case needsSelection
+    }
+
+    /// Resolves the active workspace at app launch. Resolution order:
+    /// 1. `--workspace <path>` CLI argument.
+    /// 2. `NEWSCOMB_WORKSPACE` environment variable.
+    /// 3. `WorkspaceDefaults.lastOpenedWorkspace` (if the directory still exists).
+    /// 4. Legacy `~/Library/Application Support/NewsComb/newscomb.sqlite` (if present).
+    /// 5. Returns `.needsSelection` — UI displays the first-run picker.
+    ///
+    /// **Explicit sources (CLI, env) propagate errors** — bad user input should
+    /// fail loudly. **Implicit sources log + fall through** — a deleted recent
+    /// workspace should not block the app from launching.
+    @discardableResult
+    func bootstrap(
+        commandLineArgs: [String] = CommandLine.arguments,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        legacyDirectory: URL = Workspace.legacyDirectory,
+        fileManager: FileManager = .default
+    ) throws -> BootstrapResult {
+
+        // 1. CLI argument — explicit, errors propagate
+        if let path = Self.parseWorkspaceArg(from: commandLineArgs) {
+            let url = URL(filePath: path).canonicalDirectoryURL
+            let workspace = try openWorkspace(at: url)
+            return .opened(workspace, source: .commandLine(url))
+        }
+
+        // 2. Environment variable — explicit, errors propagate
+        if let path = environment["NEWSCOMB_WORKSPACE"], !path.isEmpty {
+            let url = URL(filePath: path).canonicalDirectoryURL
+            let workspace = try openWorkspace(at: url)
+            return .opened(workspace, source: .environment(url))
+        }
+
+        // 3. Last opened — implicit, errors logged + fall through
+        if let url = defaults.lastOpenedWorkspace,
+           fileManager.fileExists(atPath: url.path(percentEncoded: false)) {
+            do {
+                let workspace = try openWorkspace(at: url)
+                return .opened(workspace, source: .lastOpened(url))
+            } catch {
+                logger.error("Failed to open last-opened workspace at \(url.path(percentEncoded: false), privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        // 4. Legacy DB — implicit, errors logged + fall through
+        let legacyDB = legacyDirectory.appending(path: Workspace.databaseFileName)
+        if fileManager.fileExists(atPath: legacyDB.path(percentEncoded: false)) {
+            do {
+                let workspace = try openWorkspace(at: legacyDirectory)
+                return .opened(workspace, source: .legacy(legacyDirectory.canonicalDirectoryURL))
+            } catch {
+                logger.error("Failed to open legacy workspace: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        // 5. Nothing found — UI must show a first-run picker
+        return .needsSelection
+    }
+
+    /// Extracts `<path>` from `--workspace <path>` or `--workspace=<path>`.
+    /// Returns `nil` if the flag isn't present or has no following value.
+    static func parseWorkspaceArg(from args: [String]) -> String? {
+        var iterator = args.makeIterator()
+        while let arg = iterator.next() {
+            if arg == "--workspace" {
+                if let next = iterator.next(), !next.isEmpty {
+                    return next
+                }
+                return nil
+            }
+            if arg.hasPrefix("--workspace=") {
+                let value = String(arg.dropFirst("--workspace=".count))
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
+    }
 }

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -176,6 +176,61 @@ final class WorkspaceCoordinator {
         return .needsSelection
     }
 
+    // MARK: - Settings copy
+
+    /// Copies every row in the source workspace's `app_settings` table into
+    /// the target workspace's `app_settings` table (UPSERT by key). Used when
+    /// the user creates a new workspace and wants their LLM keys, model
+    /// selections, prompts, and algorithm parameters carried over instead of
+    /// reset to defaults.
+    ///
+    /// Both databases are opened transiently; `Database.current` is unchanged.
+    /// The target's migration runs (creating tables and seeding defaults)
+    /// before the upsert, so any new defaults the source's DB doesn't know
+    /// about are preserved.
+    ///
+    /// **Note**: a copied `embedding_dimension` setting can mismatch the
+    /// target's vec0 tables (which were created at the seed-default
+    /// dimension). Since a brand-new workspace has no embeddings yet, the
+    /// existing dimension-mismatch reset flow will rebuild the vec0 tables
+    /// at the right size on first use.
+    func copyAppSettings(from source: URL, to target: URL) throws {
+        let sourceDB = try Database(directory: source)
+        let targetDB = try Database(directory: target)
+
+        let rows = try sourceDB.dbQueue.read { db in
+            try AppSettings.fetchAll(db)
+        }
+
+        try targetDB.dbQueue.write { db in
+            for setting in rows {
+                try db.execute(
+                    sql: """
+                        INSERT INTO app_settings (key, value) VALUES (?, ?)
+                        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    arguments: [setting.key, setting.value]
+                )
+            }
+        }
+
+        logger.notice(
+            "Copied \(rows.count, privacy: .public) app_settings rows from \(source.path(percentEncoded: false), privacy: .public) to \(target.path(percentEncoded: false), privacy: .public)"
+        )
+    }
+
+    /// Convenience: copies from the currently-active workspace to `target`.
+    /// Returns `true` if a copy actually happened, `false` if there was no
+    /// active workspace or `target` was already the active workspace.
+    @discardableResult
+    func copyAppSettingsFromCurrent(to target: URL) throws -> Bool {
+        guard let active else { return false }
+        let canonicalTarget = target.canonicalDirectoryURL
+        guard active.directory != canonicalTarget else { return false }
+        try copyAppSettings(from: active.directory, to: canonicalTarget)
+        return true
+    }
+
     // MARK: - Switching
 
     enum SwitchError: Error, LocalizedError, Equatable {

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -2,19 +2,19 @@ import Foundation
 import Observation
 import OSLog
 
-/// Owns the currently-active `Workspace` and (in later phases) the live
-/// `Database` instance for that workspace. The single source of truth for
-/// "which knowledge base is the app working with right now."
+/// Owns the currently-active `Workspace` and the live `Database` instance for
+/// that workspace. The single source of truth for "which knowledge base is the
+/// app working with right now."
 ///
-/// **Phase 1 (this file):** skeleton only — holds the active `Workspace`,
-/// exposes `setActive(_:)`. No Database wiring, no switching, no validation.
-///
-/// **Phase 2:** adds the live `Database` instance to the active workspace.
+/// **Phase 2 (this file):** opens the Database when a workspace becomes active.
+/// `openWorkspace(at:)` is the canonical entry point.
 ///
 /// **Phase 3:** `bootstrap(...)` resolves the active workspace from CLI args /
-/// env / `WorkspaceDefaults` / legacy migration / first-run picker.
+/// env / `WorkspaceDefaults` / legacy migration / first-run picker, then calls
+/// `openWorkspace(at:)`.
 ///
-/// **Phase 4:** `switchTo(_:)` with refuse-while-busy semantics.
+/// **Phase 4:** `switchWorkspace(to:)` adds refuse-while-busy semantics and
+/// MainViewModel rebuild on top of `openWorkspace(at:)`.
 @MainActor
 @Observable
 final class WorkspaceCoordinator {
@@ -23,8 +23,7 @@ final class WorkspaceCoordinator {
     /// via `init()` to keep state isolated.
     static let shared = WorkspaceCoordinator()
 
-    /// The currently-active workspace. `nil` until `setActive(_:)` is called
-    /// (Phase 3 wires this up at app launch).
+    /// The currently-active workspace. `nil` until `openWorkspace(at:)` succeeds.
     private(set) var active: Workspace?
 
     private let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceCoordinator")
@@ -34,13 +33,26 @@ final class WorkspaceCoordinator {
         self.defaults = defaults
     }
 
-    /// Records the given workspace as active and updates the recents list.
-    /// Phase 1 is the only state-change entry point; Phase 4 will route
-    /// through this after refuse-while-busy and DB swap logic.
-    func setActive(_ workspace: Workspace) {
+    /// Opens (or creates) the workspace rooted at `directory`: builds the
+    /// `Database`, runs migrations, marks it active, persists last-opened, and
+    /// updates the recents list.
+    ///
+    /// Phase 4 will guard this with refuse-while-busy and rebuild MainViewModel.
+    @discardableResult
+    func openWorkspace(at directory: URL) throws -> Workspace {
+        let workspace = Workspace(directory: directory)
+        let database = try Database(directory: workspace.directory)
+        Database.setCurrent(database)
+        recordActive(workspace)
+        return workspace
+    }
+
+    /// Records `workspace` as active and updates persistent state. Internal so
+    /// tests can drive it without spinning up a real SQLite DB.
+    func recordActive(_ workspace: Workspace) {
         active = workspace
         defaults.lastOpenedWorkspace = workspace.directory
         defaults.pushRecent(workspace.directory)
-        logger.notice("Active workspace set: \(workspace.directory.path(percentEncoded: false), privacy: .public)")
+        logger.notice("Active workspace: \(workspace.directory.path(percentEncoded: false), privacy: .public)")
     }
 }

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -26,6 +26,11 @@ final class WorkspaceCoordinator {
     /// The currently-active workspace. `nil` until `openWorkspace(at:)` succeeds.
     private(set) var active: Workspace?
 
+    /// Most-recently-used workspaces, reflected from `WorkspaceDefaults`. Mutated
+    /// here so SwiftUI views observing the coordinator see updates after
+    /// `recordActive(_:)` / `switchWorkspace(to:)` push to the recents list.
+    private(set) var recentWorkspaces: [URL] = []
+
     private let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceCoordinator")
     private let defaults: WorkspaceDefaults
     private let busyReasonsProvider: @MainActor () -> [String]
@@ -36,6 +41,14 @@ final class WorkspaceCoordinator {
     ) {
         self.defaults = defaults
         self.busyReasonsProvider = busyReasonsProvider
+        self.recentWorkspaces = defaults.recentWorkspaces
+    }
+
+    /// Removes a workspace from the recents list (e.g., the user deleted the
+    /// directory). Forwards to `WorkspaceDefaults` and refreshes the observed list.
+    func removeRecent(_ url: URL) {
+        defaults.removeRecent(url)
+        recentWorkspaces = defaults.recentWorkspaces
     }
 
     /// Reasons the app currently can't accept a workspace switch. Empty when safe.
@@ -84,6 +97,7 @@ final class WorkspaceCoordinator {
         active = workspace
         defaults.lastOpenedWorkspace = workspace.directory
         defaults.pushRecent(workspace.directory)
+        recentWorkspaces = defaults.recentWorkspaces
         logger.notice("Active workspace: \(workspace.directory.path(percentEncoded: false), privacy: .public)")
     }
 
@@ -193,6 +207,7 @@ final class WorkspaceCoordinator {
         let target = Workspace(directory: directory)
         defaults.lastOpenedWorkspace = target.directory
         defaults.pushRecent(target.directory)
+        recentWorkspaces = defaults.recentWorkspaces
         logger.notice("Switch staged to '\(target.directory.path(percentEncoded: false), privacy: .public)' — caller must relaunch")
         return target
     }

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Observation
+import OSLog
+
+/// Owns the currently-active `Workspace` and (in later phases) the live
+/// `Database` instance for that workspace. The single source of truth for
+/// "which knowledge base is the app working with right now."
+///
+/// **Phase 1 (this file):** skeleton only — holds the active `Workspace`,
+/// exposes `setActive(_:)`. No Database wiring, no switching, no validation.
+///
+/// **Phase 2:** adds the live `Database` instance to the active workspace.
+///
+/// **Phase 3:** `bootstrap(...)` resolves the active workspace from CLI args /
+/// env / `WorkspaceDefaults` / legacy migration / first-run picker.
+///
+/// **Phase 4:** `switchTo(_:)` with refuse-while-busy semantics.
+@MainActor
+@Observable
+final class WorkspaceCoordinator {
+
+    /// Production singleton. Tests should construct their own coordinator
+    /// via `init()` to keep state isolated.
+    static let shared = WorkspaceCoordinator()
+
+    /// The currently-active workspace. `nil` until `setActive(_:)` is called
+    /// (Phase 3 wires this up at app launch).
+    private(set) var active: Workspace?
+
+    private let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceCoordinator")
+    private let defaults: WorkspaceDefaults
+
+    init(defaults: WorkspaceDefaults = .shared) {
+        self.defaults = defaults
+    }
+
+    /// Records the given workspace as active and updates the recents list.
+    /// Phase 1 is the only state-change entry point; Phase 4 will route
+    /// through this after refuse-while-busy and DB swap logic.
+    func setActive(_ workspace: Workspace) {
+        active = workspace
+        defaults.lastOpenedWorkspace = workspace.directory
+        defaults.pushRecent(workspace.directory)
+        logger.notice("Active workspace set: \(workspace.directory.path(percentEncoded: false), privacy: .public)")
+    }
+}

--- a/NewsCombApp/Services/WorkspaceDefaults.swift
+++ b/NewsCombApp/Services/WorkspaceDefaults.swift
@@ -1,0 +1,85 @@
+import Foundation
+import OSLog
+
+/// App-global settings stored in `UserDefaults`. These persist across workspace
+/// switches and survive deletion of any individual workspace.
+///
+/// Workspace-scoped settings (LLM model, embedding dimension, etc.) live in
+/// each workspace's `app_settings` SQLite table — not here.
+struct WorkspaceDefaults: @unchecked Sendable {
+
+    static let maxRecents = 10
+
+    private let defaults: UserDefaults
+    private let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceDefaults")
+
+    /// Production singleton backed by `UserDefaults.standard`.
+    static let shared = WorkspaceDefaults(defaults: .standard)
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Keys
+
+    private enum Key {
+        static let lastOpened = "newscomb.workspace.lastOpened"
+        static let recents = "newscomb.workspace.recents"
+    }
+
+    // MARK: - Last-opened workspace
+
+    var lastOpenedWorkspace: URL? {
+        get {
+            guard let path = defaults.string(forKey: Key.lastOpened) else { return nil }
+            return URL(filePath: path).canonicalDirectoryURL
+        }
+        nonmutating set {
+            if let url = newValue {
+                defaults.set(url.canonicalDirectoryURL.path(percentEncoded: false), forKey: Key.lastOpened)
+            } else {
+                defaults.removeObject(forKey: Key.lastOpened)
+            }
+        }
+    }
+
+    // MARK: - Recent workspaces (most-recent first, capped at `maxRecents`)
+
+    var recentWorkspaces: [URL] {
+        get {
+            let paths = defaults.stringArray(forKey: Key.recents) ?? []
+            return paths.map { URL(filePath: $0).canonicalDirectoryURL }
+        }
+        nonmutating set {
+            let paths = newValue.map { $0.canonicalDirectoryURL.path(percentEncoded: false) }
+            defaults.set(paths, forKey: Key.recents)
+        }
+    }
+
+    /// Pushes a workspace to the front of the recents list (deduplicated; capped at `maxRecents`).
+    func pushRecent(_ url: URL) {
+        let canonical = url.canonicalDirectoryURL
+        var recents = recentWorkspaces
+        recents.removeAll { $0 == canonical }
+        recents.insert(canonical, at: 0)
+        if recents.count > Self.maxRecents {
+            recents = Array(recents.prefix(Self.maxRecents))
+        }
+        recentWorkspaces = recents
+        logger.debug("Pushed recent workspace: \(canonical.path(percentEncoded: false), privacy: .public)")
+    }
+
+    /// Removes the workspace from recents (e.g. after the directory is deleted).
+    func removeRecent(_ url: URL) {
+        let canonical = url.canonicalDirectoryURL
+        var recents = recentWorkspaces
+        recents.removeAll { $0 == canonical }
+        recentWorkspaces = recents
+    }
+
+    /// Test-only: clears all workspace-related defaults from the backing store.
+    func resetForTesting() {
+        defaults.removeObject(forKey: Key.lastOpened)
+        defaults.removeObject(forKey: Key.recents)
+    }
+}

--- a/NewsCombApp/SocialSimulation/Models/SimulationConfig.swift
+++ b/NewsCombApp/SocialSimulation/Models/SimulationConfig.swift
@@ -47,7 +47,7 @@ struct SimulationConfig: Codable, Sendable, Equatable {
         var semaphore = AppSettings.defaultSimSemaphoreLimit
 
         do {
-            try Database.shared.read { db in
+            try Database.current.read { db in
                 if let s = try AppSettings.filter(AppSettings.Columns.key == AppSettings.simAgentsPerHourMin).fetchOne(db),
                    let v = Int(s.value) { agentsMin = v }
                 if let s = try AppSettings.filter(AppSettings.Columns.key == AppSettings.simAgentsPerHourMax).fetchOne(db),

--- a/NewsCombApp/SocialSimulation/Services/ActionIngestionService.swift
+++ b/NewsCombApp/SocialSimulation/Services/ActionIngestionService.swift
@@ -9,7 +9,7 @@ import OSLog
 /// social graph tables, never to the knowledge hypergraph.
 final class ActionIngestionService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "ActionIngestion")
 
     // MARK: - Public API

--- a/NewsCombApp/SocialSimulation/Services/AgentInterviewService.swift
+++ b/NewsCombApp/SocialSimulation/Services/AgentInterviewService.swift
@@ -7,7 +7,7 @@ import OSLog
 /// or via direct LLM call when OASIS is stopped.
 final class AgentInterviewService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let graphService = SocialGraphService()
     private let logger = Logger(subsystem: "com.newscomb", category: "AgentInterviewService")
 

--- a/NewsCombApp/SocialSimulation/Services/AgentProfileService.swift
+++ b/NewsCombApp/SocialSimulation/Services/AgentProfileService.swift
@@ -10,7 +10,7 @@ import OSLog
 /// and `social_connection` tables.
 final class AgentProfileService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "AgentProfileService")
 
     // MARK: - Callbacks

--- a/NewsCombApp/SocialSimulation/Services/NodeClassificationService.swift
+++ b/NewsCombApp/SocialSimulation/Services/NodeClassificationService.swift
@@ -14,7 +14,7 @@ import FoundationModels
 /// hypergraph_node.node_type.
 final class NodeClassificationService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "NodeClassification")
 
     typealias StatusCallback = @MainActor @Sendable (String) -> Void

--- a/NewsCombApp/SocialSimulation/Services/OasisExportService.swift
+++ b/NewsCombApp/SocialSimulation/Services/OasisExportService.swift
@@ -8,7 +8,7 @@ import OSLog
 /// configuration, and the Python simulation script.
 final class OasisExportService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "OasisExportService")
 
     // MARK: - Public API

--- a/NewsCombApp/SocialSimulation/Services/SimulationEngine.swift
+++ b/NewsCombApp/SocialSimulation/Services/SimulationEngine.swift
@@ -22,7 +22,7 @@ actor SimulationEngine {
     private var statusContinuation: AsyncStream<SimulationStatus>.Continuation?
     private var agentMapping: [Int: Int64] = [:]
 
-    private let database = Database.shared
+    private let database = Database.current
     private let ingestionService = ActionIngestionService()
     private let logger = Logger(subsystem: "com.newscomb", category: "SimulationEngine")
 

--- a/NewsCombApp/SocialSimulation/Services/SimulationReportService.swift
+++ b/NewsCombApp/SocialSimulation/Services/SimulationReportService.swift
@@ -10,7 +10,7 @@ import OSLog
 /// 2. **Insight Agent**: identifies narratives, consensus/contention, influential agents
 final class SimulationReportService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let graphService = SocialGraphService()
     private let logger = Logger(subsystem: "com.newscomb", category: "SimulationReportService")
 

--- a/NewsCombApp/SocialSimulation/Services/SocialGraphService.swift
+++ b/NewsCombApp/SocialSimulation/Services/SocialGraphService.swift
@@ -8,7 +8,7 @@ import OSLog
 /// for context. Writes only to `social_*` and `agent_*` tables.
 final class SocialGraphService: Sendable {
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "SocialGraphService")
 
     // MARK: - Agent Queries

--- a/NewsCombApp/SocialSimulation/ViewModels/SimulationDashboardViewModel.swift
+++ b/NewsCombApp/SocialSimulation/ViewModels/SimulationDashboardViewModel.swift
@@ -38,7 +38,7 @@ final class SimulationDashboardViewModel {
     private let profileService = AgentProfileService()
     private let exportService = OasisExportService()
     private let graphService = SocialGraphService()
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "SimDashboard")
 
     private var statusTask: Task<Void, Never>? {

--- a/NewsCombApp/SocialSimulation/ViewModels/SimulationListViewModel.swift
+++ b/NewsCombApp/SocialSimulation/ViewModels/SimulationListViewModel.swift
@@ -16,7 +16,7 @@ final class SimulationListViewModel {
 
     // MARK: - Internal
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "SimulationListViewModel")
 
     // MARK: - Loading

--- a/NewsCombApp/SocialSimulation/Views/SimulationConfigView.swift
+++ b/NewsCombApp/SocialSimulation/Views/SimulationConfigView.swift
@@ -225,7 +225,7 @@ struct SimulationConfigView: View {
         let personaTypes = AgentProfileService.personaNodeTypes
         do {
             let types = personaTypes.map { "'\($0)'" }.joined(separator: ", ")
-            try Database.shared.read { db in
+            try Database.current.read { db in
                 // Try typed persona nodes first
                 var nodes = try HypergraphNode.fetchAll(db, sql: """
                     SELECT n.*

--- a/NewsCombApp/ViewModels/AnswerDetailViewModel.swift
+++ b/NewsCombApp/ViewModels/AnswerDetailViewModel.swift
@@ -85,7 +85,7 @@ final class AnswerDetailViewModel {
     private let deepAnalysisService = DeepAnalysisService()
     private let queryHistoryService = QueryHistoryService()
     private let userRoleService = UserRoleService()
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "AnswerDetailViewModel")
 
     // MARK: - History Mode Initializer

--- a/NewsCombApp/ViewModels/FeedItemsViewModel.swift
+++ b/NewsCombApp/ViewModels/FeedItemsViewModel.swift
@@ -45,7 +45,7 @@ class FeedItemsViewModel {
     var selectedSourceId: Int64?
     var searchText: String = ""
 
-    private let database = Database.shared
+    private let database = Database.current
 
     var filteredItems: [FeedItemDisplay] {
         var result = items

--- a/NewsCombApp/ViewModels/GraphViewModel.swift
+++ b/NewsCombApp/ViewModels/GraphViewModel.swift
@@ -100,7 +100,7 @@ class GraphViewModel {
     private let graphDataService = GraphDataService()
 
     @ObservationIgnored
-    private let database = Database.shared
+    private let database = Database.current
 
     @ObservationIgnored
     private var layout = ForceDirectedLayout()

--- a/NewsCombApp/ViewModels/MainViewModel.swift
+++ b/NewsCombApp/ViewModels/MainViewModel.swift
@@ -71,7 +71,7 @@ class MainViewModel {
     var classificationProgress: Double = 0
     var classificationStatus: String = ""
 
-    private let database = Database.shared
+    private let database = Database.current
 
     @ObservationIgnored
     private let opmlService = OPMLImportService()

--- a/NewsCombApp/ViewModels/SettingsViewModel.swift
+++ b/NewsCombApp/ViewModels/SettingsViewModel.swift
@@ -153,7 +153,7 @@ class SettingsViewModel {
     /// the dimension the vec0 tables were built with, and graph data exists.
     var needsGraphRebuild = false
 
-    private let database = Database.shared
+    private let database = Database.current
 
     func loadData() {
         loadRSSSources()

--- a/NewsCombApp/ViewModels/ThemeClusterViewModel.swift
+++ b/NewsCombApp/ViewModels/ThemeClusterViewModel.swift
@@ -67,7 +67,7 @@ final class ThemeClusterViewModel {
 
     private let clusteringService = ClusteringService()
     private let clusterLabelingService = ClusterLabelingService()
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "ThemeClusterViewModel")
 
     // MARK: - Loading

--- a/NewsCombApp/ViewModels/ThemeDetailViewModel.swift
+++ b/NewsCombApp/ViewModels/ThemeDetailViewModel.swift
@@ -47,7 +47,7 @@ final class ThemeDetailViewModel {
 
     // MARK: - Internal
 
-    private let database = Database.shared
+    private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "ThemeDetailViewModel")
 
     init(cluster: StoryCluster) {

--- a/NewsCombApp/Views/ContentView.swift
+++ b/NewsCombApp/Views/ContentView.swift
@@ -1,8 +1,23 @@
 import SwiftUI
 
 struct ContentView: View {
+
+    private let coordinator = WorkspaceCoordinator.shared
+
     var body: some View {
         MainView()
+            .navigationTitle(coordinator.active.map { "NewsComb — \($0.name)" } ?? "NewsComb")
+            #if os(macOS)
+            .sheet(isPresented: Binding(
+                get: { coordinator.active == nil },
+                set: { _ in }
+            )) {
+                FirstRunWorkspaceSheet(coordinator: coordinator) { url in
+                    try? coordinator.openWorkspace(at: url)
+                }
+                .interactiveDismissDisabled(true)
+            }
+            #endif
     }
 }
 

--- a/NewsCombApp/Views/FirstRunWorkspaceSheet.swift
+++ b/NewsCombApp/Views/FirstRunWorkspaceSheet.swift
@@ -1,0 +1,103 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+/// First-run sheet shown when bootstrap returns `.needsSelection` — neither a
+/// CLI/env workspace, nor a remembered last-opened, nor a legacy DB exists.
+/// Lets the user create or open a workspace before any UI demands data.
+struct FirstRunWorkspaceSheet: View {
+
+    @Bindable var coordinator: WorkspaceCoordinator
+    let onChosen: (URL) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "folder.badge.plus")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+
+            Text("Welcome to NewsComb")
+                .font(.title.bold())
+
+            Text("A workspace is a folder containing the SQLite database for an independent knowledge base. Create a new one or open an existing folder to begin.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 420)
+
+            VStack(spacing: 12) {
+                Button {
+                    pickFolder(create: true)
+                } label: {
+                    Label("Create New Workspace", systemImage: "plus.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button {
+                    pickFolder(create: false)
+                } label: {
+                    Label("Open Existing Workspace", systemImage: "folder")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .frame(maxWidth: 320)
+
+            if !coordinator.recentWorkspaces.isEmpty {
+                Divider().frame(maxWidth: 320)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Recent")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.secondary)
+                    ForEach(coordinator.recentWorkspaces.prefix(5), id: \.self) { url in
+                        Button {
+                            onChosen(url)
+                            dismiss()
+                        } label: {
+                            HStack {
+                                Image(systemName: "folder")
+                                Text(url.lastPathComponent)
+                                Spacer()
+                                Text(url.path(percentEncoded: false))
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .frame(maxWidth: 320)
+            }
+        }
+        .padding(40)
+        .frame(minWidth: 480, minHeight: 480)
+    }
+
+    private func pickFolder(create: Bool) {
+        let panel = NSOpenPanel()
+        panel.canCreateDirectories = create
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = create
+            ? "Choose a folder for the new NewsComb workspace."
+            : "Choose an existing NewsComb workspace folder."
+        panel.prompt = create ? "Use Folder" : "Open Workspace"
+        if create, let documents = try? FileManager.default.url(
+            for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false
+        ) {
+            panel.directoryURL = documents.appending(path: "NewsComb-Workspaces")
+        }
+        if panel.runModal() == .OK, let url = panel.url {
+            onChosen(url)
+            dismiss()
+        }
+    }
+}
+#endif

--- a/NewsCombApp/Views/SettingsView.swift
+++ b/NewsCombApp/Views/SettingsView.swift
@@ -6,6 +6,9 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            #if os(macOS)
+            WorkspaceSettingsSection(coordinator: WorkspaceCoordinator.shared)
+            #endif
             feedSettingsSection
             userRolesSection
             knowledgeExtractionSection

--- a/NewsCombApp/Views/WorkspaceCommands.swift
+++ b/NewsCombApp/Views/WorkspaceCommands.swift
@@ -26,7 +26,7 @@ struct WorkspaceCommands: Commands {
             Menu("Open Recent Workspace") {
                 ForEach(coordinator.recentWorkspaces, id: \.self) { url in
                     Button(url.lastPathComponent) {
-                        attemptSwitch(to: url)
+                        attemptSwitch(to: url, copyIfNew: false)
                     }
                 }
                 if !coordinator.recentWorkspaces.isEmpty {
@@ -64,7 +64,7 @@ struct WorkspaceCommands: Commands {
         panel.message = "Choose a folder for the new NewsComb workspace. The folder may be empty or contain an existing newscomb.sqlite."
         panel.prompt = "Use Folder"
         if panel.runModal() == .OK, let url = panel.url {
-            attemptSwitch(to: url)
+            attemptSwitch(to: url, copyIfNew: true)
         }
     }
 
@@ -77,12 +77,20 @@ struct WorkspaceCommands: Commands {
         panel.message = "Choose a folder containing a NewsComb workspace."
         panel.prompt = "Open Workspace"
         if panel.runModal() == .OK, let url = panel.url {
-            attemptSwitch(to: url)
+            attemptSwitch(to: url, copyIfNew: false)
         }
     }
 
-    private func attemptSwitch(to url: URL) {
+    /// Routes a workspace switch through `WorkspaceCoordinator.switchWorkspace`,
+    /// optionally copying `app_settings` from the current workspace first if
+    /// the target is brand-new (used for File → New Workspace…). Failure during
+    /// settings copy aborts the switch — better to surface the error than
+    /// relaunch into a workspace with default settings the user didn't expect.
+    private func attemptSwitch(to url: URL, copyIfNew: Bool) {
         do {
+            if copyIfNew && Self.isNewWorkspace(at: url) {
+                _ = try coordinator.copyAppSettingsFromCurrent(to: url)
+            }
             _ = try coordinator.switchWorkspace(to: url)
             confirmAndRelaunch(to: url)
         } catch let error as WorkspaceCoordinator.SwitchError {
@@ -96,6 +104,12 @@ struct WorkspaceCommands: Commands {
                 message: error.localizedDescription
             )
         }
+    }
+
+    /// True when the target folder doesn't already contain a `newscomb.sqlite`.
+    private static func isNewWorkspace(at url: URL) -> Bool {
+        let dbFile = url.appending(path: Workspace.databaseFileName)
+        return !FileManager.default.fileExists(atPath: dbFile.path(percentEncoded: false))
     }
 
     private func confirmAndRelaunch(to url: URL) {

--- a/NewsCombApp/Views/WorkspaceCommands.swift
+++ b/NewsCombApp/Views/WorkspaceCommands.swift
@@ -82,14 +82,16 @@ struct WorkspaceCommands: Commands {
     }
 
     /// Routes a workspace switch through `WorkspaceCoordinator.switchWorkspace`,
-    /// optionally copying `app_settings` from the current workspace first if
-    /// the target is brand-new (used for File → New Workspace…). Failure during
-    /// settings copy aborts the switch — better to surface the error than
-    /// relaunch into a workspace with default settings the user didn't expect.
+    /// optionally provisioning the target as a brand-new workspace first
+    /// (used for File → New Workspace…). Provisioning copies the current
+    /// workspace's portable settings, suppresses default-feed seeding, and
+    /// clears any seeded feeds. Failure during provisioning aborts the
+    /// switch — better to surface the error than relaunch into an
+    /// inconsistent workspace.
     private func attemptSwitch(to url: URL, copyIfNew: Bool) {
         do {
             if copyIfNew && Self.isNewWorkspace(at: url) {
-                _ = try coordinator.copyAppSettingsFromCurrent(to: url)
+                _ = try coordinator.provisionNewWorkspace(at: url)
             }
             _ = try coordinator.switchWorkspace(to: url)
             confirmAndRelaunch(to: url)

--- a/NewsCombApp/Views/WorkspaceCommands.swift
+++ b/NewsCombApp/Views/WorkspaceCommands.swift
@@ -1,0 +1,123 @@
+#if os(macOS)
+import AppKit
+import OSLog
+import SwiftUI
+
+/// File-menu commands for managing workspaces. Wires into the main `WindowGroup`
+/// via `.commands { WorkspaceCommands(coordinator: ...) }`.
+struct WorkspaceCommands: Commands {
+
+    @Bindable var coordinator: WorkspaceCoordinator
+
+    private static let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceCommands")
+
+    var body: some Commands {
+        CommandGroup(after: .newItem) {
+            Button("New Workspace…") {
+                handleNewWorkspace()
+            }
+            .keyboardShortcut("n", modifiers: [.shift, .command])
+
+            Button("Open Workspace…") {
+                handleOpenWorkspace()
+            }
+            .keyboardShortcut("o", modifiers: [.shift, .command])
+
+            Menu("Open Recent Workspace") {
+                ForEach(coordinator.recentWorkspaces, id: \.self) { url in
+                    Button(url.lastPathComponent) {
+                        attemptSwitch(to: url)
+                    }
+                }
+                if !coordinator.recentWorkspaces.isEmpty {
+                    Divider()
+                    Button("Clear Menu") {
+                        for url in coordinator.recentWorkspaces {
+                            coordinator.removeRecent(url)
+                        }
+                    }
+                }
+            }
+            .disabled(coordinator.recentWorkspaces.isEmpty)
+
+            Divider()
+
+            Button("Reveal Workspace in Finder") {
+                if let dir = coordinator.active?.directory {
+                    NSWorkspace.shared.activateFileViewerSelecting([dir])
+                }
+            }
+            .disabled(coordinator.active == nil)
+
+            Divider()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func handleNewWorkspace() {
+        let panel = NSOpenPanel()
+        panel.canCreateDirectories = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose a folder for the new NewsComb workspace. The folder may be empty or contain an existing newscomb.sqlite."
+        panel.prompt = "Use Folder"
+        if panel.runModal() == .OK, let url = panel.url {
+            attemptSwitch(to: url)
+        }
+    }
+
+    private func handleOpenWorkspace() {
+        let panel = NSOpenPanel()
+        panel.canCreateDirectories = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose a folder containing a NewsComb workspace."
+        panel.prompt = "Open Workspace"
+        if panel.runModal() == .OK, let url = panel.url {
+            attemptSwitch(to: url)
+        }
+    }
+
+    private func attemptSwitch(to url: URL) {
+        do {
+            _ = try coordinator.switchWorkspace(to: url)
+            confirmAndRelaunch(to: url)
+        } catch let error as WorkspaceCoordinator.SwitchError {
+            showError(
+                title: "Cannot switch workspace",
+                message: error.errorDescription ?? "Unknown error"
+            )
+        } catch {
+            showError(
+                title: "Switch failed",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private func confirmAndRelaunch(to url: URL) {
+        let alert = NSAlert()
+        alert.messageText = "Relaunch NewsComb?"
+        alert.informativeText = "NewsComb will quit and reopen with the workspace at:\n\n\(url.path(percentEncoded: false))"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Relaunch")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            Self.logger.notice("User confirmed relaunch for workspace at \(url.path(percentEncoded: false), privacy: .public)")
+            WorkspaceRelauncher.relaunchApp()
+        }
+    }
+
+    private func showError(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}
+#endif

--- a/NewsCombApp/Views/WorkspaceRelauncher.swift
+++ b/NewsCombApp/Views/WorkspaceRelauncher.swift
@@ -1,0 +1,31 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import OSLog
+
+/// Quits and relaunches the running NewsComb app. Used after a workspace
+/// switch so the new workspace is bootstrapped from a fresh process.
+///
+/// The relaunch is performed by spawning a short-lived `/bin/sh` that waits
+/// for the current process to terminate, then runs `open <bundle>`. This is
+/// the standard macOS app-relaunch pattern — NSApplication has no built-in
+/// "relaunch" because the process must outlive itself.
+enum WorkspaceRelauncher {
+
+    private static let logger = Logger(subsystem: "com.newscomb.app", category: "WorkspaceRelauncher")
+
+    static func relaunchApp() {
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(filePath: "/bin/sh")
+        // Quote the bundle path defensively — macOS app paths may contain spaces.
+        task.arguments = ["-c", "sleep 0.4 && open \"\(bundlePath)\""]
+        do {
+            try task.run()
+        } catch {
+            logger.error("Failed to spawn relaunch helper: \(error.localizedDescription, privacy: .public)")
+        }
+        NSApplication.shared.terminate(nil)
+    }
+}
+#endif

--- a/NewsCombApp/Views/WorkspaceSettingsSection.swift
+++ b/NewsCombApp/Views/WorkspaceSettingsSection.swift
@@ -8,6 +8,10 @@ struct WorkspaceSettingsSection: View {
 
     @Bindable var coordinator: WorkspaceCoordinator
 
+    private var isOnDefault: Bool {
+        coordinator.active?.directory == Workspace.legacyDirectory.canonicalDirectoryURL
+    }
+
     var body: some View {
         Section {
             if let active = coordinator.active {
@@ -26,9 +30,18 @@ struct WorkspaceSettingsSection: View {
                     Button("Reveal in Finder", systemImage: "folder") {
                         NSWorkspace.shared.activateFileViewerSelecting([active.directory])
                     }
+                    Button("Open Default Workspace", systemImage: "house") {
+                        switchToDefault()
+                    }
+                    .disabled(isOnDefault || !coordinator.canSwitchWorkspace)
+                    .help(
+                        isOnDefault
+                            ? "You're already using the default workspace at \(Workspace.legacyDirectory.path(percentEncoded: false))."
+                            : "Switch to the legacy default workspace at \(Workspace.legacyDirectory.path(percentEncoded: false))."
+                    )
                     Spacer()
                     Button("Switch Workspace…", systemImage: "rectangle.2.swap") {
-                        switchWorkspace()
+                        switchToPickedFolder()
                     }
                     .disabled(!coordinator.canSwitchWorkspace)
                 }
@@ -50,7 +63,9 @@ struct WorkspaceSettingsSection: View {
         }
     }
 
-    private func switchWorkspace() {
+    // MARK: - Actions
+
+    private func switchToPickedFolder() {
         let panel = NSOpenPanel()
         panel.canCreateDirectories = true
         panel.canChooseDirectories = true
@@ -59,33 +74,51 @@ struct WorkspaceSettingsSection: View {
         panel.message = "Choose a workspace folder."
         panel.prompt = "Open Workspace"
         guard panel.runModal() == .OK, let url = panel.url else { return }
+        attemptSwitch(to: url)
+    }
 
+    private func switchToDefault() {
+        attemptSwitch(to: Workspace.legacyDirectory)
+    }
+
+    private func attemptSwitch(to url: URL) {
         do {
             _ = try coordinator.switchWorkspace(to: url)
-            let alert = NSAlert()
-            alert.messageText = "Relaunch NewsComb?"
-            alert.informativeText = "NewsComb will quit and reopen with the workspace at:\n\n\(url.path(percentEncoded: false))"
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "Relaunch")
-            alert.addButton(withTitle: "Cancel")
-            if alert.runModal() == .alertFirstButtonReturn {
-                WorkspaceRelauncher.relaunchApp()
-            }
+            confirmAndRelaunch(to: url)
         } catch let error as WorkspaceCoordinator.SwitchError {
-            let alert = NSAlert()
-            alert.messageText = "Cannot switch workspace"
-            alert.informativeText = error.errorDescription ?? "Unknown error"
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
+            showAlert(
+                title: "Cannot switch workspace",
+                message: error.errorDescription ?? "Unknown error",
+                style: .warning
+            )
         } catch {
-            let alert = NSAlert()
-            alert.messageText = "Switch failed"
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
+            showAlert(
+                title: "Switch failed",
+                message: error.localizedDescription,
+                style: .warning
+            )
         }
+    }
+
+    private func confirmAndRelaunch(to url: URL) {
+        let alert = NSAlert()
+        alert.messageText = "Relaunch NewsComb?"
+        alert.informativeText = "NewsComb will quit and reopen with the workspace at:\n\n\(url.path(percentEncoded: false))"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Relaunch")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            WorkspaceRelauncher.relaunchApp()
+        }
+    }
+
+    private func showAlert(title: String, message: String, style: NSAlert.Style) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = style
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }
 #endif

--- a/NewsCombApp/Views/WorkspaceSettingsSection.swift
+++ b/NewsCombApp/Views/WorkspaceSettingsSection.swift
@@ -1,0 +1,91 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+/// Settings pane section showing the active workspace and offering switch /
+/// reveal-in-Finder. Drop-in for `SettingsView`'s `Form`.
+struct WorkspaceSettingsSection: View {
+
+    @Bindable var coordinator: WorkspaceCoordinator
+
+    var body: some View {
+        Section {
+            if let active = coordinator.active {
+                LabeledContent("Active Workspace") {
+                    Text(active.name).bold()
+                }
+                LabeledContent("Path") {
+                    Text(active.directory.path(percentEncoded: false))
+                        .font(.callout.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+                HStack {
+                    Button("Reveal in Finder", systemImage: "folder") {
+                        NSWorkspace.shared.activateFileViewerSelecting([active.directory])
+                    }
+                    Spacer()
+                    Button("Switch Workspace…", systemImage: "rectangle.2.swap") {
+                        switchWorkspace()
+                    }
+                    .disabled(!coordinator.canSwitchWorkspace)
+                }
+                if !coordinator.busyReasons.isEmpty {
+                    Text("Switching is disabled while: \(coordinator.busyReasons.joined(separator: ", ")).")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                LabeledContent("Active Workspace") {
+                    Text("none — open or create one from the File menu")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Workspace")
+        } footer: {
+            Text("A workspace is a folder containing the SQLite database for an independent knowledge base. Switching workspaces relaunches NewsComb.")
+        }
+    }
+
+    private func switchWorkspace() {
+        let panel = NSOpenPanel()
+        panel.canCreateDirectories = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose a workspace folder."
+        panel.prompt = "Open Workspace"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            _ = try coordinator.switchWorkspace(to: url)
+            let alert = NSAlert()
+            alert.messageText = "Relaunch NewsComb?"
+            alert.informativeText = "NewsComb will quit and reopen with the workspace at:\n\n\(url.path(percentEncoded: false))"
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Relaunch")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                WorkspaceRelauncher.relaunchApp()
+            }
+        } catch let error as WorkspaceCoordinator.SwitchError {
+            let alert = NSAlert()
+            alert.messageText = "Cannot switch workspace"
+            alert.informativeText = error.errorDescription ?? "Unknown error"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = "Switch failed"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
+    }
+}
+#endif

--- a/NewsCombAppTests/DatabaseWorkspaceInitTests.swift
+++ b/NewsCombAppTests/DatabaseWorkspaceInitTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import GRDB
+@testable import NewsCombApp
+
+/// Direct tests for `Database.init(directory:)` and the
+/// `current` / `setCurrent(_:)` accessors introduced for the workspace feature.
+final class DatabaseWorkspaceInitTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "DBInitTests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() async throws {
+        Database.resetCurrentForTesting()
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        tempRoot = nil
+        try await super.tearDown()
+    }
+
+    func testInitCreatesDirectoryWhenAbsent() throws {
+        let dir = tempRoot.appending(path: "Brand/New/Path")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir.path(percentEncoded: false)))
+        _ = try Database(directory: dir)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dir.path(percentEncoded: false)))
+    }
+
+    func testInitCreatesSQLiteFile() throws {
+        let dir = tempRoot.appending(path: "Alpha")
+        _ = try Database(directory: dir)
+        let dbFile = dir.appending(path: "newscomb.sqlite")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dbFile.path(percentEncoded: false)))
+    }
+
+    func testInitRunsMigrationCreatingCoreTables() throws {
+        let dir = tempRoot.appending(path: "Beta")
+        let db = try Database(directory: dir)
+
+        // Spot-check several core tables created in migrate()
+        let expected = ["rss_source", "feed_item", "app_settings", "hypergraph_node", "hypergraph_edge"]
+        let names = try db.dbQueue.read { db -> Set<String> in
+            let rows = try Row.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type='table'")
+            return Set(rows.compactMap { $0["name"] as String? })
+        }
+        for table in expected {
+            XCTAssertTrue(names.contains(table), "Expected table '\(table)' to exist after migrate()")
+        }
+    }
+
+    func testWorkspaceDirectoryIsCanonicalized() throws {
+        // Trailing slash should be stripped; the property should round-trip
+        // to the same URL as the canonical workspace directory.
+        let dir = tempRoot.appending(path: "Gamma/")
+        let db = try Database(directory: dir)
+        XCTAssertEqual(db.workspaceDirectory, tempRoot.appending(path: "Gamma").canonicalDirectoryURL)
+    }
+
+    func testTwoInstancesAtDifferentPathsAreIndependent() throws {
+        let dirA = tempRoot.appending(path: "A")
+        let dirB = tempRoot.appending(path: "B")
+        let dbA = try Database(directory: dirA)
+        let dbB = try Database(directory: dirB)
+        XCTAssertNotEqual(dbA.workspaceDirectory, dbB.workspaceDirectory)
+        XCTAssertNotEqual(dbA.dbQueue.path, dbB.dbQueue.path)
+    }
+
+    // MARK: - current / setCurrent
+
+    func testSetCurrentReplacesActiveDatabase() throws {
+        let dirA = tempRoot.appending(path: "First")
+        let dirB = tempRoot.appending(path: "Second")
+        let dbA = try Database(directory: dirA)
+        let dbB = try Database(directory: dirB)
+
+        Database.setCurrent(dbA)
+        XCTAssertEqual(Database.current.workspaceDirectory, dirA.canonicalDirectoryURL)
+
+        Database.setCurrent(dbB)
+        XCTAssertEqual(Database.current.workspaceDirectory, dirB.canonicalDirectoryURL)
+    }
+
+    func testResetCurrentForTestingClearsActive() throws {
+        let dir = tempRoot.appending(path: "Reset")
+        let db = try Database(directory: dir)
+        Database.setCurrent(db)
+        XCTAssertEqual(Database.current.workspaceDirectory, dir.canonicalDirectoryURL)
+        Database.resetCurrentForTesting()
+        // After reset, accessing `current` lazy-bootstraps to legacy. We don't
+        // assert on the bootstrapped value here (it would touch the user's
+        // real Application Support); we only verify that reset doesn't crash
+        // and a subsequent setCurrent works.
+        Database.setCurrent(db)
+        XCTAssertEqual(Database.current.workspaceDirectory, dir.canonicalDirectoryURL)
+    }
+}

--- a/NewsCombAppTests/MCPWorkspaceValidatorTests.swift
+++ b/NewsCombAppTests/MCPWorkspaceValidatorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import NewsCombApp
+
+final class MCPWorkspaceValidatorTests: XCTestCase {
+
+    private let workspaceA = URL(filePath: "/tmp/workspaces/A").canonicalDirectoryURL
+    private let workspaceB = URL(filePath: "/tmp/workspaces/B").canonicalDirectoryURL
+
+    // MARK: - Allow paths
+
+    func testAllowsRequestWithNoHeader() {
+        let result = MCPWorkspaceValidator.validate(requestedHeader: nil, active: workspaceA)
+        XCTAssertNil(result)
+    }
+
+    func testAllowsRequestWithEmptyHeader() {
+        let result = MCPWorkspaceValidator.validate(requestedHeader: "", active: workspaceA)
+        XCTAssertNil(result)
+    }
+
+    func testAllowsMatchingHeader() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceA.path(percentEncoded: false),
+            active: workspaceA
+        )
+        XCTAssertNil(result)
+    }
+
+    func testAllowsMatchingHeaderIgnoringTrailingSlash() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceA.path(percentEncoded: false) + "/",
+            active: workspaceA
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Reject paths
+
+    func testRejectsHeaderWhenNoActiveWorkspace() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceA.path(percentEncoded: false),
+            active: nil
+        )
+        guard case let .noActiveWorkspace(requested) = result else {
+            return XCTFail("Expected .noActiveWorkspace, got \(String(describing: result))")
+        }
+        XCTAssertEqual(requested, workspaceA)
+    }
+
+    func testRejectsMismatchedHeader() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceB.path(percentEncoded: false),
+            active: workspaceA
+        )
+        guard case let .mismatch(active, requested) = result else {
+            return XCTFail("Expected .mismatch, got \(String(describing: result))")
+        }
+        XCTAssertEqual(active, workspaceA)
+        XCTAssertEqual(requested, workspaceB)
+    }
+
+    // MARK: - Error formatting
+
+    func testNoActiveWorkspaceMessageMentionsRequested() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceA.path(percentEncoded: false),
+            active: nil
+        )
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.message.contains(workspaceA.path(percentEncoded: false)))
+    }
+
+    func testMismatchMessageMentionsBothPaths() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceB.path(percentEncoded: false),
+            active: workspaceA
+        )
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.message.contains(workspaceA.path(percentEncoded: false)))
+        XCTAssertTrue(result!.message.contains(workspaceB.path(percentEncoded: false)))
+    }
+
+    func testFailureCodeIsServerDefined() {
+        let result = MCPWorkspaceValidator.validate(
+            requestedHeader: workspaceB.path(percentEncoded: false),
+            active: workspaceA
+        )
+        XCTAssertEqual(result?.code, -32001)
+    }
+
+    // MARK: - JSON-RPC error response formatting
+
+    func testMakeJSONRPCErrorBodyHasJSONRPCField() throws {
+        let data = MCPHTTPServer.makeJSONRPCErrorHTTPResponse(
+            requestId: "abc",
+            code: -32001,
+            message: "boom"
+        )
+        let httpString = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(httpString.contains("HTTP/1.1 400"))
+        XCTAssertTrue(httpString.contains("Content-Type: application/json"))
+        XCTAssertTrue(httpString.contains("\"jsonrpc\":\"2.0\""))
+        XCTAssertTrue(httpString.contains("\"id\":\"abc\""))
+        XCTAssertTrue(httpString.contains("\"code\":-32001"))
+        XCTAssertTrue(httpString.contains("\"message\":\"boom\""))
+    }
+
+    func testMakeJSONRPCErrorBodyEscapesQuotesInMessage() {
+        let data = MCPHTTPServer.makeJSONRPCErrorHTTPResponse(
+            requestId: nil,
+            code: -32001,
+            message: "has \"quotes\" and \\ backslash"
+        )
+        let httpString = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(httpString.contains("\\\"quotes\\\""))
+        XCTAssertTrue(httpString.contains("\\\\ backslash"))
+    }
+
+    func testExtractRequestIdFromStringId() {
+        let body = Data(#"{"jsonrpc":"2.0","id":"req-42","method":"tools/list"}"#.utf8)
+        XCTAssertEqual(MCPHTTPServer.extractRequestId(from: body), "req-42")
+    }
+
+    func testExtractRequestIdFromIntId() {
+        let body = Data(#"{"jsonrpc":"2.0","id":7,"method":"tools/list"}"#.utf8)
+        XCTAssertEqual(MCPHTTPServer.extractRequestId(from: body), "7")
+    }
+
+    func testExtractRequestIdReturnsNilWhenAbsent() {
+        let body = Data(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.utf8)
+        XCTAssertNil(MCPHTTPServer.extractRequestId(from: body))
+    }
+}

--- a/NewsCombAppTests/OasisEnvironmentServiceTests.swift
+++ b/NewsCombAppTests/OasisEnvironmentServiceTests.swift
@@ -304,13 +304,13 @@ final class OasisEnvironmentServiceTests: XCTestCase {
         // The knowledge graph may have nodes with NULL node_type.
         // Verify the database has nodes (from the live DB) and that
         // the service can find some even without typed persona nodes.
-        let nodeCount = try Database.shared.read { db in
+        let nodeCount = try Database.current.read { db in
             try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM hypergraph_node")
         }
 
         // Only run this test if the DB has data
         if let count = nodeCount, count > 0 {
-            let hasTypedPersonas = try Database.shared.read { db in
+            let hasTypedPersonas = try Database.current.read { db in
                 let types = AgentProfileService.personaNodeTypes.map { "'\($0)'" }.joined(separator: ", ")
                 let count = try Int.fetchOne(db, sql: """
                     SELECT COUNT(*) FROM hypergraph_node
@@ -319,7 +319,7 @@ final class OasisEnvironmentServiceTests: XCTestCase {
                 return (count ?? 0) > 0
             }
 
-            let fallbackNodes = try Database.shared.read { db in
+            let fallbackNodes = try Database.current.read { db in
                 try Int.fetchOne(db, sql: """
                     SELECT COUNT(*) FROM hypergraph_node
                     WHERE LENGTH(label) <= 80

--- a/NewsCombAppTests/OasisSimulationIntegrationTests.swift
+++ b/NewsCombAppTests/OasisSimulationIntegrationTests.swift
@@ -27,7 +27,7 @@ final class OasisSimulationIntegrationTests: XCTestCase {
         pythonPath = python
 
         // Load OpenRouter API key
-        let loadedApiKey: String? = try Database.shared.read { db in
+        let loadedApiKey: String? = try Database.current.read { db in
             try String.fetchOne(db, sql: "SELECT value FROM app_settings WHERE key = ?",
                                 arguments: [AppSettings.openRouterKey])
         }

--- a/NewsCombAppTests/WorkspaceCoordinatorBootstrapTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorBootstrapTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import NewsCombApp
+
+@MainActor
+final class WorkspaceCoordinatorBootstrapTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var workspaceDefaults: WorkspaceDefaults!
+    private var sut: WorkspaceCoordinator!
+    private var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "newscomb.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        workspaceDefaults = WorkspaceDefaults(defaults: defaults)
+        sut = WorkspaceCoordinator(defaults: workspaceDefaults)
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "BootstrapTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempRoot)
+        Database.resetCurrentForTesting()
+        sut = nil
+        workspaceDefaults = nil
+        defaults = nil
+        suiteName = nil
+        tempRoot = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - parseWorkspaceArg
+
+    func testParseWorkspaceArgWithSpaceForm() {
+        let args = ["NewsCombApp", "--workspace", "/tmp/Tech"]
+        XCTAssertEqual(WorkspaceCoordinator.parseWorkspaceArg(from: args), "/tmp/Tech")
+    }
+
+    func testParseWorkspaceArgWithEqualsForm() {
+        let args = ["NewsCombApp", "--workspace=/tmp/Tech"]
+        XCTAssertEqual(WorkspaceCoordinator.parseWorkspaceArg(from: args), "/tmp/Tech")
+    }
+
+    func testParseWorkspaceArgReturnsNilWhenAbsent() {
+        let args = ["NewsCombApp", "--other-flag", "value"]
+        XCTAssertNil(WorkspaceCoordinator.parseWorkspaceArg(from: args))
+    }
+
+    func testParseWorkspaceArgReturnsNilWhenSpaceFormHasNoValue() {
+        let args = ["NewsCombApp", "--workspace"]
+        XCTAssertNil(WorkspaceCoordinator.parseWorkspaceArg(from: args))
+    }
+
+    func testParseWorkspaceArgReturnsNilWhenEqualsFormIsEmpty() {
+        let args = ["NewsCombApp", "--workspace="]
+        XCTAssertNil(WorkspaceCoordinator.parseWorkspaceArg(from: args))
+    }
+
+    func testParseWorkspaceArgIgnoresArgsBefore() {
+        let args = ["NewsCombApp", "-NSDocumentRevisionsDebugMode", "YES", "--workspace", "/tmp/Tech"]
+        XCTAssertEqual(WorkspaceCoordinator.parseWorkspaceArg(from: args), "/tmp/Tech")
+    }
+
+    // MARK: - bootstrap resolution priority
+
+    func testBootstrapFromCommandLine() throws {
+        let dir = tempRoot.appending(path: "FromCLI")
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp", "--workspace", dir.path(percentEncoded: false)],
+            environment: [:],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case let .opened(workspace, source) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, dir.canonicalDirectoryURL)
+        if case .commandLine = source { /* ok */ } else { XCTFail("Expected .commandLine source, got \(source)") }
+    }
+
+    func testBootstrapFromEnvironment() throws {
+        let dir = tempRoot.appending(path: "FromEnv")
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: ["NEWSCOMB_WORKSPACE": dir.path(percentEncoded: false)],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case let .opened(workspace, source) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, dir.canonicalDirectoryURL)
+        if case .environment = source { /* ok */ } else { XCTFail("Expected .environment source, got \(source)") }
+    }
+
+    func testCommandLineTakesPriorityOverEnvironment() throws {
+        let cli = tempRoot.appending(path: "CLI")
+        let env = tempRoot.appending(path: "Env")
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp", "--workspace", cli.path(percentEncoded: false)],
+            environment: ["NEWSCOMB_WORKSPACE": env.path(percentEncoded: false)],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case let .opened(workspace, _) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, cli.canonicalDirectoryURL)
+    }
+
+    func testEnvironmentTakesPriorityOverLastOpened() throws {
+        let env = tempRoot.appending(path: "Env")
+        let last = tempRoot.appending(path: "Last")
+        try FileManager.default.createDirectory(at: last, withIntermediateDirectories: true)
+        workspaceDefaults.lastOpenedWorkspace = last
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: ["NEWSCOMB_WORKSPACE": env.path(percentEncoded: false)],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case let .opened(workspace, _) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, env.canonicalDirectoryURL)
+    }
+
+    func testBootstrapFromLastOpened() throws {
+        let dir = tempRoot.appending(path: "LastOpened")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        workspaceDefaults.lastOpenedWorkspace = dir
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: [:],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case let .opened(workspace, source) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, dir.canonicalDirectoryURL)
+        if case .lastOpened = source { /* ok */ } else { XCTFail("Expected .lastOpened source, got \(source)") }
+    }
+
+    func testBootstrapFallsThroughWhenLastOpenedDirectoryMissing() throws {
+        // Last-opened points at a directory that doesn't exist on disk.
+        let missing = tempRoot.appending(path: "DoesNotExistOnDisk")
+        workspaceDefaults.lastOpenedWorkspace = missing
+
+        // No CLI, no env, no legacy → should return needsSelection.
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: [:],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case .needsSelection = result else {
+            return XCTFail("Expected .needsSelection, got \(result)")
+        }
+    }
+
+    func testBootstrapFromLegacy() throws {
+        // Simulate the legacy DB by creating the directory + file.
+        let fakeLegacyDir = tempRoot.appending(path: "fake-legacy")
+        try FileManager.default.createDirectory(at: fakeLegacyDir, withIntermediateDirectories: true)
+        let dbFile = fakeLegacyDir.appending(path: Workspace.databaseFileName)
+        // openWorkspace will overwrite/migrate this; an empty placeholder is fine.
+        try Data().write(to: dbFile)
+
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: [:],
+            legacyDirectory: fakeLegacyDir
+        )
+        guard case let .opened(workspace, source) = result else {
+            return XCTFail("Expected .opened, got \(result)")
+        }
+        XCTAssertEqual(workspace.directory, fakeLegacyDir.canonicalDirectoryURL)
+        if case .legacy = source { /* ok */ } else { XCTFail("Expected .legacy source, got \(source)") }
+    }
+
+    func testBootstrapReturnsNeedsSelectionWhenNothingConfigured() throws {
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: [:],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy-not-present")
+        )
+        guard case .needsSelection = result else {
+            return XCTFail("Expected .needsSelection, got \(result)")
+        }
+        XCTAssertNil(sut.active)
+    }
+
+    func testBootstrapEmptyEnvironmentVarIsTreatedAsAbsent() throws {
+        let result = try sut.bootstrap(
+            commandLineArgs: ["NewsCombApp"],
+            environment: ["NEWSCOMB_WORKSPACE": ""],
+            legacyDirectory: tempRoot.appending(path: "fake-legacy")
+        )
+        guard case .needsSelection = result else {
+            return XCTFail("Expected .needsSelection, got \(result)")
+        }
+    }
+}

--- a/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import NewsCombApp
+
+@MainActor
+final class WorkspaceCoordinatorCopySettingsTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var workspaceDefaults: WorkspaceDefaults!
+    private var sut: WorkspaceCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "newscomb.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        workspaceDefaults = WorkspaceDefaults(defaults: defaults)
+        sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "CopySettings-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempRoot)
+        Database.resetCurrentForTesting()
+        sut = nil
+        workspaceDefaults = nil
+        defaults = nil
+        suiteName = nil
+        tempRoot = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func writeSetting(_ key: String, value: String, in db: Database) throws {
+        try db.dbQueue.write { conn in
+            try conn.execute(sql: """
+                INSERT INTO app_settings (key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """, arguments: [key, value])
+        }
+    }
+
+    private func readSetting(_ key: String, in db: Database) throws -> String? {
+        try db.dbQueue.read { conn in
+            try String.fetchOne(conn, sql: "SELECT value FROM app_settings WHERE key = ?", arguments: [key])
+        }
+    }
+
+    // MARK: - copyAppSettings(from:to:)
+
+    func testCopyOverwritesTargetSeedDefaultsWithSourceValues() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        let sourceDB = try Database(directory: sourceDir)
+
+        // Override two settings the seed sets to defaults.
+        try writeSetting("llm_provider", value: "openrouter", in: sourceDB)
+        try writeSetting("ollama_model", value: "qwen2.5:14b", in: sourceDB)
+
+        try sut.copyAppSettings(from: sourceDir, to: targetDir)
+
+        let targetDB = try Database(directory: targetDir)
+        XCTAssertEqual(try readSetting("llm_provider", in: targetDB), "openrouter")
+        XCTAssertEqual(try readSetting("ollama_model", in: targetDB), "qwen2.5:14b")
+    }
+
+    func testCopyCarriesUserOnlyKeysIntoTarget() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        let sourceDB = try Database(directory: sourceDir)
+
+        // Settings the user added (e.g. an API key not in the seed defaults).
+        try writeSetting("openrouter_key", value: "sk-test-12345", in: sourceDB)
+
+        try sut.copyAppSettings(from: sourceDir, to: targetDir)
+
+        let targetDB = try Database(directory: targetDir)
+        XCTAssertEqual(try readSetting("openrouter_key", in: targetDB), "sk-test-12345")
+    }
+
+    func testCopyPreservesTargetSeedKeysSourceLacks() throws {
+        // If the source DB pre-dates a setting that the target's migration
+        // seeds (e.g. a new default added in a future schema), copy should
+        // keep the target's seeded value rather than blanking it.
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        let sourceDB = try Database(directory: sourceDir)
+
+        // Remove a known seeded key from the source so it appears "missing".
+        try sourceDB.dbQueue.write { conn in
+            try conn.execute(sql: "DELETE FROM app_settings WHERE key = ?", arguments: ["embedding_provider"])
+        }
+
+        try sut.copyAppSettings(from: sourceDir, to: targetDir)
+
+        let targetDB = try Database(directory: targetDir)
+        // Target's seed should still be present.
+        let value = try readSetting("embedding_provider", in: targetDB)
+        XCTAssertNotNil(value)
+        XCTAssertFalse(value!.isEmpty)
+    }
+
+    func testCopyCountsAllSourceRows() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        let sourceDB = try Database(directory: sourceDir)
+
+        // Add 3 user-only keys.
+        try writeSetting("custom_key_1", value: "v1", in: sourceDB)
+        try writeSetting("custom_key_2", value: "v2", in: sourceDB)
+        try writeSetting("custom_key_3", value: "v3", in: sourceDB)
+
+        try sut.copyAppSettings(from: sourceDir, to: targetDir)
+
+        let targetDB = try Database(directory: targetDir)
+        for i in 1...3 {
+            XCTAssertEqual(try readSetting("custom_key_\(i)", in: targetDB), "v\(i)")
+        }
+    }
+
+    // MARK: - copyAppSettingsFromCurrent(to:)
+
+    func testCopyFromCurrentReturnsFalseWhenNoActive() throws {
+        XCTAssertNil(sut.active)
+        let target = tempRoot.appending(path: "Target")
+        let copied = try sut.copyAppSettingsFromCurrent(to: target)
+        XCTAssertFalse(copied)
+    }
+
+    func testCopyFromCurrentReturnsFalseWhenTargetEqualsActive() throws {
+        let dir = tempRoot.appending(path: "Same")
+        try sut.openWorkspace(at: dir)
+        let copied = try sut.copyAppSettingsFromCurrent(to: dir)
+        XCTAssertFalse(copied, "Copying to the active workspace should be a no-op")
+    }
+
+    func testCopyFromCurrentSucceedsAndCarriesValues() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+
+        // Make Source the active workspace, then put a known value in it.
+        try sut.openWorkspace(at: sourceDir)
+        try writeSetting("openrouter_key", value: "sk-current-99", in: Database.current)
+
+        let copied = try sut.copyAppSettingsFromCurrent(to: targetDir)
+        XCTAssertTrue(copied)
+
+        let targetDB = try Database(directory: targetDir)
+        XCTAssertEqual(try readSetting("openrouter_key", in: targetDB), "sk-current-99")
+    }
+}

--- a/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
@@ -152,4 +152,37 @@ final class WorkspaceCoordinatorCopySettingsTests: XCTestCase {
         let targetDB = try Database(directory: targetDir)
         XCTAssertEqual(try readSetting("openrouter_key", in: targetDB), "sk-current-99")
     }
+
+    // MARK: - Non-portable schema-state keys
+
+    func testCopyDoesNotOverwriteActiveEmbeddingDimension() throws {
+        // active_embedding_dimension is schema metadata — it tracks the size
+        // the vec0 tables were physically created with. Copying it would make
+        // `Database.migrate` skip the vec0 rebuild on next launch even though
+        // the carried-over `embedding_dimension` differs from on-disk schema.
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        let sourceDB = try Database(directory: sourceDir)
+
+        // Source claims its tables are 1024-d (lying for the test — we don't
+        // actually rebuild here, we just want to verify the copy skips this key).
+        try writeSetting(AppSettings.activeEmbeddingDimension, value: "1024", in: sourceDB)
+        // Also bump the user-intent setting so the test is realistic.
+        try writeSetting(AppSettings.embeddingDimension, value: "1024", in: sourceDB)
+
+        // Capture the target's seeded value before the copy.
+        let targetDB = try Database(directory: targetDir)
+        let preCopyActiveDim = try readSetting(AppSettings.activeEmbeddingDimension, in: targetDB)
+
+        try sut.copyAppSettings(from: sourceDir, to: targetDir)
+
+        // User intent: should now match source.
+        XCTAssertEqual(try readSetting(AppSettings.embeddingDimension, in: targetDB), "1024")
+        // Schema state: must remain whatever the target's own migration set it to.
+        let postCopyActiveDim = try readSetting(AppSettings.activeEmbeddingDimension, in: targetDB)
+        XCTAssertEqual(
+            postCopyActiveDim, preCopyActiveDim,
+            "active_embedding_dimension must not be copied — it tracks the target's vec0 table size"
+        )
+    }
 }

--- a/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
@@ -155,6 +155,79 @@ final class WorkspaceCoordinatorCopySettingsTests: XCTestCase {
 
     // MARK: - Non-portable schema-state keys
 
+    // MARK: - provisionNewWorkspace
+
+    func testProvisionNewWorkspaceCopiesSettings() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        try sut.openWorkspace(at: sourceDir)
+        try writeSetting("openrouter_key", value: "sk-x-77", in: Database.current)
+
+        let provisioned = try sut.provisionNewWorkspace(at: targetDir)
+        XCTAssertTrue(provisioned)
+
+        let targetDB = try Database(directory: targetDir)
+        XCTAssertEqual(try readSetting("openrouter_key", in: targetDB), "sk-x-77")
+    }
+
+    func testProvisionNewWorkspaceLeavesNoFeeds() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        try sut.openWorkspace(at: sourceDir)
+        try sut.provisionNewWorkspace(at: targetDir)
+
+        let targetDB = try Database(directory: targetDir)
+        let count = try targetDB.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")
+        }
+        XCTAssertEqual(count, 0, "Provisioned workspace should have no RSS feeds")
+    }
+
+    func testProvisionedWorkspaceDoesNotReseedFeedsAfterReopen() throws {
+        let sourceDir = tempRoot.appending(path: "Source")
+        let targetDir = tempRoot.appending(path: "Target")
+        try sut.openWorkspace(at: sourceDir)
+        try sut.provisionNewWorkspace(at: targetDir)
+
+        // First reopen — runs migrate again (which would re-seed if the flag
+        // weren't honored).
+        do {
+            let reopened = try Database(directory: targetDir)
+            let count = try reopened.dbQueue.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")
+            }
+            XCTAssertEqual(count, 0, "Reopen #1: feeds must stay empty")
+            XCTAssertEqual(
+                try readSetting(AppSettings.feedSeedSuppressed, in: reopened),
+                "1",
+                "Suppression flag should still be set after reopen"
+            )
+        }
+
+        // Second reopen — defensive: the flag still survives multiple opens.
+        do {
+            let reopened = try Database(directory: targetDir)
+            let count = try reopened.dbQueue.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")
+            }
+            XCTAssertEqual(count, 0, "Reopen #2: feeds must stay empty")
+        }
+    }
+
+    func testProvisionReturnsFalseWhenNoActive() throws {
+        XCTAssertNil(sut.active)
+        let target = tempRoot.appending(path: "Target")
+        XCTAssertFalse(try sut.provisionNewWorkspace(at: target))
+    }
+
+    func testProvisionReturnsFalseWhenTargetEqualsActive() throws {
+        let dir = tempRoot.appending(path: "Same")
+        try sut.openWorkspace(at: dir)
+        XCTAssertFalse(try sut.provisionNewWorkspace(at: dir))
+    }
+
+    // MARK: - Schema-state exclusions
+
     func testCopyDoesNotOverwriteActiveEmbeddingDimension() throws {
         // active_embedding_dimension is schema metadata — it tracks the size
         // the vec0 tables were physically created with. Copying it would make

--- a/NewsCombAppTests/WorkspaceCoordinatorSwitchTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorSwitchTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import NewsCombApp
+
+@MainActor
+final class WorkspaceCoordinatorSwitchTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var workspaceDefaults: WorkspaceDefaults!
+    private var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "newscomb.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        workspaceDefaults = WorkspaceDefaults(defaults: defaults)
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "SwitchTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempRoot)
+        Database.resetCurrentForTesting()
+        workspaceDefaults = nil
+        defaults = nil
+        suiteName = nil
+        tempRoot = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Busy gating
+
+    func testCanSwitchWorkspaceTrueWhenNoReasons() {
+        let sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        XCTAssertTrue(sut.canSwitchWorkspace)
+        XCTAssertEqual(sut.busyReasons, [])
+    }
+
+    func testCanSwitchWorkspaceFalseWhenBusy() {
+        let sut = WorkspaceCoordinator(
+            defaults: workspaceDefaults,
+            busyReasonsProvider: { ["processing hypergraph"] }
+        )
+        XCTAssertFalse(sut.canSwitchWorkspace)
+        XCTAssertEqual(sut.busyReasons, ["processing hypergraph"])
+    }
+
+    // MARK: - switchWorkspace
+
+    func testSwitchSucceedsWhenNotBusy() throws {
+        let sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        let target = tempRoot.appending(path: "Target")
+        let result = try sut.switchWorkspace(to: target)
+        XCTAssertEqual(result.directory, target.canonicalDirectoryURL)
+    }
+
+    func testSwitchRefusesWhenBusy() {
+        let sut = WorkspaceCoordinator(
+            defaults: workspaceDefaults,
+            busyReasonsProvider: { ["processing hypergraph", "refreshing feeds"] }
+        )
+        let target = tempRoot.appending(path: "Target")
+        XCTAssertThrowsError(try sut.switchWorkspace(to: target)) { error in
+            guard case let WorkspaceCoordinator.SwitchError.busy(reasons) = error else {
+                return XCTFail("Expected .busy, got \(error)")
+            }
+            XCTAssertEqual(reasons, ["processing hypergraph", "refreshing feeds"])
+        }
+    }
+
+    func testSwitchPersistsLastOpened() throws {
+        let sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        let target = tempRoot.appending(path: "Target")
+        try sut.switchWorkspace(to: target)
+        XCTAssertEqual(workspaceDefaults.lastOpenedWorkspace, target.canonicalDirectoryURL)
+    }
+
+    func testSwitchPushesToRecents() throws {
+        let sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        let target = tempRoot.appending(path: "Target")
+        try sut.switchWorkspace(to: target)
+        XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, target.canonicalDirectoryURL)
+    }
+
+    func testSwitchDoesNotChangeActiveOrOpenDatabase() throws {
+        // switchWorkspace is "stage + relaunch"; it should not mutate live state.
+        let sut = WorkspaceCoordinator(defaults: workspaceDefaults, busyReasonsProvider: { [] })
+        XCTAssertNil(sut.active)
+        let target = tempRoot.appending(path: "Target")
+        try sut.switchWorkspace(to: target)
+        XCTAssertNil(sut.active, "switchWorkspace should not set active — caller relaunches")
+        // No newscomb.sqlite created at the target — the caller's bootstrap will do it.
+        let dbFile = target.appending(path: Workspace.databaseFileName)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dbFile.path(percentEncoded: false)))
+    }
+
+    func testSwitchErrorDescriptionListsAllReasons() {
+        let error = WorkspaceCoordinator.SwitchError.busy(reasons: ["a", "b", "c"])
+        XCTAssertEqual(error.errorDescription, "Cannot switch workspace while busy: a, b, c")
+    }
+}

--- a/NewsCombAppTests/WorkspaceCoordinatorTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import NewsCombApp
+
+@MainActor
+final class WorkspaceCoordinatorTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var workspaceDefaults: WorkspaceDefaults!
+    private var sut: WorkspaceCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "newscomb.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        workspaceDefaults = WorkspaceDefaults(defaults: defaults)
+        sut = WorkspaceCoordinator(defaults: workspaceDefaults)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = nil
+        workspaceDefaults = nil
+        defaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+
+    func testActiveIsNilOnInit() {
+        XCTAssertNil(sut.active)
+    }
+
+    func testSetActiveStoresWorkspace() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
+        sut.setActive(workspace)
+        XCTAssertEqual(sut.active, workspace)
+    }
+
+    func testSetActivePersistsLastOpened() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
+        sut.setActive(workspace)
+        XCTAssertEqual(workspaceDefaults.lastOpenedWorkspace, workspace.directory)
+    }
+
+    func testSetActivePushesToRecents() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
+        sut.setActive(workspace)
+        XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, workspace.directory)
+    }
+
+    func testSetActiveTwiceMovesMostRecentToFront() {
+        let a = Workspace(directory: URL(filePath: "/tmp/A"))
+        let b = Workspace(directory: URL(filePath: "/tmp/B"))
+        sut.setActive(a)
+        sut.setActive(b)
+        sut.setActive(a)
+        XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, a.directory)
+        XCTAssertEqual(workspaceDefaults.recentWorkspaces.count, 2)
+    }
+}

--- a/NewsCombAppTests/WorkspaceCoordinatorTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorTests.swift
@@ -8,6 +8,7 @@ final class WorkspaceCoordinatorTests: XCTestCase {
     private var defaults: UserDefaults!
     private var workspaceDefaults: WorkspaceDefaults!
     private var sut: WorkspaceCoordinator!
+    private var tempRoot: URL!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -15,46 +16,83 @@ final class WorkspaceCoordinatorTests: XCTestCase {
         defaults = UserDefaults(suiteName: suiteName)!
         workspaceDefaults = WorkspaceDefaults(defaults: defaults)
         sut = WorkspaceCoordinator(defaults: workspaceDefaults)
+        tempRoot = FileManager.default.temporaryDirectory
+            .appending(path: "WorkspaceCoordinatorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
     }
 
     override func tearDown() async throws {
         defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempRoot)
+        Database.resetCurrentForTesting()
         sut = nil
         workspaceDefaults = nil
         defaults = nil
         suiteName = nil
+        tempRoot = nil
         try await super.tearDown()
     }
+
+    // MARK: - Bookkeeping (recordActive)
 
     func testActiveIsNilOnInit() {
         XCTAssertNil(sut.active)
     }
 
-    func testSetActiveStoresWorkspace() {
+    func testRecordActiveStoresWorkspace() {
         let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
-        sut.setActive(workspace)
+        sut.recordActive(workspace)
         XCTAssertEqual(sut.active, workspace)
     }
 
-    func testSetActivePersistsLastOpened() {
+    func testRecordActivePersistsLastOpened() {
         let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
-        sut.setActive(workspace)
+        sut.recordActive(workspace)
         XCTAssertEqual(workspaceDefaults.lastOpenedWorkspace, workspace.directory)
     }
 
-    func testSetActivePushesToRecents() {
+    func testRecordActivePushesToRecents() {
         let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
-        sut.setActive(workspace)
+        sut.recordActive(workspace)
         XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, workspace.directory)
     }
 
-    func testSetActiveTwiceMovesMostRecentToFront() {
+    func testRecordActiveTwiceMovesMostRecentToFront() {
         let a = Workspace(directory: URL(filePath: "/tmp/A"))
         let b = Workspace(directory: URL(filePath: "/tmp/B"))
-        sut.setActive(a)
-        sut.setActive(b)
-        sut.setActive(a)
+        sut.recordActive(a)
+        sut.recordActive(b)
+        sut.recordActive(a)
         XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, a.directory)
         XCTAssertEqual(workspaceDefaults.recentWorkspaces.count, 2)
+    }
+
+    // MARK: - openWorkspace (real DB I/O)
+
+    func testOpenWorkspaceCreatesDatabaseFile() throws {
+        let dir = tempRoot.appending(path: "Alpha")
+        let workspace = try sut.openWorkspace(at: dir)
+        XCTAssertEqual(sut.active, workspace)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: workspace.databaseFileURL.path(percentEncoded: false)),
+            "Database file should be created on openWorkspace"
+        )
+    }
+
+    func testOpenWorkspaceSetsDatabaseCurrent() throws {
+        let dir = tempRoot.appending(path: "Beta")
+        try sut.openWorkspace(at: dir)
+        XCTAssertEqual(
+            Database.current.workspaceDirectory,
+            dir.canonicalDirectoryURL,
+            "Database.current should point at the just-opened workspace"
+        )
+    }
+
+    func testOpenWorkspaceRecordsBookkeeping() throws {
+        let dir = tempRoot.appending(path: "Gamma")
+        try sut.openWorkspace(at: dir)
+        XCTAssertEqual(workspaceDefaults.lastOpenedWorkspace, dir.canonicalDirectoryURL)
+        XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, dir.canonicalDirectoryURL)
     }
 }

--- a/NewsCombAppTests/WorkspaceCoordinatorTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorTests.swift
@@ -95,4 +95,30 @@ final class WorkspaceCoordinatorTests: XCTestCase {
         XCTAssertEqual(workspaceDefaults.lastOpenedWorkspace, dir.canonicalDirectoryURL)
         XCTAssertEqual(workspaceDefaults.recentWorkspaces.first, dir.canonicalDirectoryURL)
     }
+
+    // MARK: - Observable recentWorkspaces
+
+    func testRecentWorkspacesInitiallyMatchesDefaults() {
+        // Pre-seed defaults, then build a new coordinator; recents should reflect.
+        workspaceDefaults.pushRecent(URL(filePath: "/tmp/Pre1"))
+        workspaceDefaults.pushRecent(URL(filePath: "/tmp/Pre2"))
+        let coordinator = WorkspaceCoordinator(defaults: workspaceDefaults)
+        XCTAssertEqual(coordinator.recentWorkspaces.count, 2)
+        XCTAssertEqual(coordinator.recentWorkspaces.first?.lastPathComponent, "Pre2")
+    }
+
+    func testRecordActiveUpdatesObservedRecents() {
+        XCTAssertTrue(sut.recentWorkspaces.isEmpty)
+        sut.recordActive(Workspace(directory: URL(filePath: "/tmp/Tech")))
+        XCTAssertEqual(sut.recentWorkspaces.count, 1)
+        XCTAssertEqual(sut.recentWorkspaces.first?.lastPathComponent, "Tech")
+    }
+
+    func testRemoveRecentUpdatesObservedList() {
+        sut.recordActive(Workspace(directory: URL(filePath: "/tmp/A")))
+        sut.recordActive(Workspace(directory: URL(filePath: "/tmp/B")))
+        sut.removeRecent(URL(filePath: "/tmp/A"))
+        XCTAssertEqual(sut.recentWorkspaces.count, 1)
+        XCTAssertEqual(sut.recentWorkspaces.first?.lastPathComponent, "B")
+    }
 }

--- a/NewsCombAppTests/WorkspaceDefaultsTests.swift
+++ b/NewsCombAppTests/WorkspaceDefaultsTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import NewsCombApp
+
+final class WorkspaceDefaultsTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var sut: WorkspaceDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "newscomb.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        sut = WorkspaceDefaults(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - lastOpenedWorkspace
+
+    func testLastOpenedWorkspaceIsNilByDefault() {
+        XCTAssertNil(sut.lastOpenedWorkspace)
+    }
+
+    func testLastOpenedWorkspaceRoundtrips() {
+        let url = URL(filePath: "/tmp/Tech")
+        sut.lastOpenedWorkspace = url
+        XCTAssertEqual(sut.lastOpenedWorkspace, url.standardizedFileURL)
+    }
+
+    func testLastOpenedWorkspaceClearsOnNil() {
+        sut.lastOpenedWorkspace = URL(filePath: "/tmp/Tech")
+        sut.lastOpenedWorkspace = nil
+        XCTAssertNil(sut.lastOpenedWorkspace)
+    }
+
+    // MARK: - recentWorkspaces
+
+    func testRecentsEmptyByDefault() {
+        XCTAssertTrue(sut.recentWorkspaces.isEmpty)
+    }
+
+    func testPushRecentInsertsAtFront() {
+        sut.pushRecent(URL(filePath: "/tmp/A"))
+        sut.pushRecent(URL(filePath: "/tmp/B"))
+        let recents = sut.recentWorkspaces
+        XCTAssertEqual(recents.count, 2)
+        XCTAssertEqual(recents.first?.lastPathComponent, "B")
+        XCTAssertEqual(recents.last?.lastPathComponent, "A")
+    }
+
+    func testPushRecentDeduplicates() {
+        sut.pushRecent(URL(filePath: "/tmp/A"))
+        sut.pushRecent(URL(filePath: "/tmp/B"))
+        sut.pushRecent(URL(filePath: "/tmp/A"))
+        let recents = sut.recentWorkspaces
+        XCTAssertEqual(recents.count, 2)
+        XCTAssertEqual(recents.first?.lastPathComponent, "A")
+        XCTAssertEqual(recents.last?.lastPathComponent, "B")
+    }
+
+    func testPushRecentDeduplicatesIgnoringTrailingSlash() {
+        sut.pushRecent(URL(filePath: "/tmp/A"))
+        sut.pushRecent(URL(filePath: "/tmp/A/"))
+        XCTAssertEqual(sut.recentWorkspaces.count, 1)
+    }
+
+    func testPushRecentCapsAtMax() {
+        for i in 0..<(WorkspaceDefaults.maxRecents + 5) {
+            sut.pushRecent(URL(filePath: "/tmp/W\(i)"))
+        }
+        let recents = sut.recentWorkspaces
+        XCTAssertEqual(recents.count, WorkspaceDefaults.maxRecents)
+        // Most recent push should be at the front
+        XCTAssertEqual(
+            recents.first?.lastPathComponent,
+            "W\(WorkspaceDefaults.maxRecents + 4)"
+        )
+    }
+
+    func testRemoveRecent() {
+        sut.pushRecent(URL(filePath: "/tmp/A"))
+        sut.pushRecent(URL(filePath: "/tmp/B"))
+        sut.removeRecent(URL(filePath: "/tmp/A"))
+        XCTAssertEqual(sut.recentWorkspaces.count, 1)
+        XCTAssertEqual(sut.recentWorkspaces.first?.lastPathComponent, "B")
+    }
+}

--- a/NewsCombAppTests/WorkspaceTests.swift
+++ b/NewsCombAppTests/WorkspaceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import NewsCombApp
+
+final class WorkspaceTests: XCTestCase {
+
+    func testInitCanonicalizesDirectory() {
+        let raw = URL(filePath: "/tmp/./foo/../foo/")
+        let workspace = Workspace(directory: raw)
+        XCTAssertEqual(workspace.directory.path(percentEncoded: false), "/tmp/foo")
+    }
+
+    func testNameIsLastPathComponent() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Workspaces/Tech"))
+        XCTAssertEqual(workspace.name, "Tech")
+    }
+
+    func testDatabaseFileURLAppendsCorrectFilename() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Workspaces/Tech"))
+        XCTAssertEqual(
+            workspace.databaseFileURL.path(percentEncoded: false),
+            "/tmp/Workspaces/Tech/newscomb.sqlite"
+        )
+    }
+
+    func testEqualityIgnoresTrailingSlash() {
+        let a = Workspace(directory: URL(filePath: "/tmp/Tech"))
+        let b = Workspace(directory: URL(filePath: "/tmp/Tech/"))
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func testIdentityIsDirectory() {
+        let workspace = Workspace(directory: URL(filePath: "/tmp/Tech"))
+        XCTAssertEqual(workspace.id, workspace.directory)
+    }
+
+    func testLegacyDirectoryPointsAtAppSupport() {
+        let legacy = Workspace.legacyDirectory.path(percentEncoded: false)
+        XCTAssertTrue(
+            legacy.contains("Application Support/NewsComb"),
+            "Expected legacy directory under Application Support, got: \(legacy)"
+        )
+    }
+
+    func testDefaultWorkspacesRootIsUnderDocuments() {
+        let root = Workspace.defaultWorkspacesRoot.path(percentEncoded: false)
+        XCTAssertTrue(
+            root.contains("Documents/NewsComb-Workspaces"),
+            "Expected default root under Documents, got: \(root)"
+        )
+    }
+}

--- a/NewsCombMCPBridge/Sources/main.swift
+++ b/NewsCombMCPBridge/Sources/main.swift
@@ -15,6 +15,28 @@ import Foundation
 
 let endpoint = URL(string: "http://127.0.0.1:63548/mcp")!
 let sessionHeader = "X-Session-Id"
+let workspaceHeader = "X-Workspace"
+
+/// The workspace path the bridge is bound to (from `--workspace <path>` /
+/// `--workspace=<path>` / `NEWSCOMB_WORKSPACE` env var). When set, every HTTP
+/// request asserts this workspace via the `X-Workspace` header. The app
+/// rejects with a JSON-RPC error if its active workspace doesn't match.
+let workspacePath: String? = {
+    var iterator = CommandLine.arguments.makeIterator()
+    _ = iterator.next() // executable name
+    while let arg = iterator.next() {
+        if arg == "--workspace" { return iterator.next() }
+        if arg.hasPrefix("--workspace=") {
+            let value = String(arg.dropFirst("--workspace=".count))
+            return value.isEmpty ? nil : value
+        }
+    }
+    if let env = ProcessInfo.processInfo.environment["NEWSCOMB_WORKSPACE"], !env.isEmpty {
+        return env
+    }
+    return nil
+}()
+
 let urlSession: URLSession = {
     let config = URLSessionConfiguration.ephemeral
     config.timeoutIntervalForRequest = 300
@@ -71,6 +93,11 @@ func postToApp(body: Data) async throws -> Data? {
     // Include session ID if we have one
     if let sessionId = currentSessionId {
         request.setValue(sessionId, forHTTPHeaderField: sessionHeader)
+    }
+
+    // Assert the bound workspace, if any, on every request.
+    if let workspacePath {
+        request.setValue(workspacePath, forHTTPHeaderField: workspaceHeader)
     }
 
     let (data, response) = try await urlSession.data(for: request)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ NewsComb picks the active workspace on launch using the first match it finds:
 
 ### Managing workspaces from the UI
 
-- **File → New Workspace…** (⇧⌘N) — pick or create a folder. When the folder is brand-new, the current workspace's settings (LLM provider + API keys, embedding model, prompts, algorithm parameters) are copied into the new one so you don't have to reconfigure.
+- **File → New Workspace…** (⇧⌘N) — pick or create a folder. When the folder is brand-new, the current workspace's settings (LLM provider + API keys, embedding model, prompts, algorithm parameters) are copied into the new one so you don't have to reconfigure. Feeds are **not** copied — the new workspace starts empty so you can pick feeds appropriate to its domain.
 - **File → Open Workspace…** (⇧⌘O) — open an existing workspace folder. No settings copy — the target's own settings are used.
 - **File → Open Recent Workspace** — last 10 workspaces.
 - **File → Reveal Workspace in Finder**.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ Since the app is not signed with an Apple Developer certificate, macOS will bloc
 
 After this one-time setup, the app will open normally.
 
+## Workspaces
+
+A **workspace** is a folder on disk that holds the SQLite database and any side artifacts for one knowledge base. NewsComb supports multiple workspaces so you can keep, say, a "Tech News" workspace separate from a "Confluence" workspace. Each workspace has its own settings, feeds, articles, knowledge graph, and theme clusters.
+
+### What's in a workspace
+
+```
+~/Documents/NewsComb-Workspaces/Tech/
+  newscomb.sqlite     ← all data and settings for this workspace
+```
+
+### Resolution order at launch
+
+NewsComb picks the active workspace on launch using the first match it finds:
+
+1. `--workspace <path>` command-line argument
+2. `NEWSCOMB_WORKSPACE` environment variable
+3. The last workspace you opened (remembered in `UserDefaults`)
+4. The legacy database at `~/Library/Application Support/NewsComb/newscomb.sqlite`, if present (existing installs migrate seamlessly)
+5. A first-run picker sheet — Create New Workspace or Open Existing
+
+### Managing workspaces from the UI
+
+- **File → New Workspace…** (⇧⌘N) — pick or create a folder.
+- **File → Open Workspace…** (⇧⌘O) — open an existing workspace folder.
+- **File → Open Recent Workspace** — last 10 workspaces.
+- **File → Reveal Workspace in Finder**.
+- **Settings → Workspace** — shows the active path and a Switch Workspace button.
+
+Switching workspaces relaunches the app so each workspace gets a clean process state. NewsComb refuses to switch while long-running jobs (knowledge graph processing, RSS refresh, OPML import, theme clustering, etc.) are in flight — wait for them to finish or cancel them first.
+
+### App-global vs. workspace-scoped settings
+
+| Scope | Location | Examples |
+|-------|----------|----------|
+| **Workspace** | `app_settings` table inside each workspace's `newscomb.sqlite` | LLM model, embedding dimension, RAG params, feeds, themes |
+| **App-global** | `UserDefaults` | last-opened workspace, recent workspaces list |
+
 ## Setup
 
 ### Embeddings
@@ -133,11 +171,15 @@ Add the following to your project's `.mcp.json` file (create it in the repositor
   "mcpServers": {
     "newscomb": {
       "command": "/path/to/NewsComb/NewsCombMCPBridge/.build/release/newscomb-mcp-bridge",
-      "args": []
+      "args": ["--workspace", "/Users/you/Documents/NewsComb-Workspaces/Tech"]
     }
   }
 }
 ```
+
+The `--workspace` argument is **optional but recommended**. When set, the bridge asserts that the running NewsComb app is on the matching workspace; mismatches surface a clear JSON-RPC error rather than silently returning data from the wrong knowledge base. You can also pass the workspace via the `NEWSCOMB_WORKSPACE` environment variable.
+
+You can keep a separate `.mcp.json` per project, each pointing at a different workspace — open the matching workspace in NewsComb (File → Open Workspace…) before starting the Claude Code session.
 
 ### Setup for Claude Desktop
 
@@ -150,7 +192,7 @@ Add the same configuration to your Claude Desktop settings file:
   "mcpServers": {
     "newscomb": {
       "command": "/path/to/NewsComb/NewsCombMCPBridge/.build/release/newscomb-mcp-bridge",
-      "args": []
+      "args": ["--workspace", "/Users/you/Documents/NewsComb-Workspaces/Tech"]
     }
   }
 }
@@ -159,8 +201,9 @@ Add the same configuration to your Claude Desktop settings file:
 ### Prerequisites
 
 1. **NewsComb must be running** — launch the app before starting Claude Code. The MCP HTTP server starts automatically on app launch.
-2. The app must have RSS sources configured and articles fetched
-3. The knowledge extraction pipeline must have processed at least some articles (check Settings for extraction status)
+2. The running app must be on the workspace your `--workspace` arg names (or omit the arg to skip the check).
+3. The app must have RSS sources configured and articles fetched.
+4. The knowledge extraction pipeline must have processed at least some articles (check Settings for extraction status).
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ NewsComb picks the active workspace on launch using the first match it finds:
 
 ### Managing workspaces from the UI
 
-- **File → New Workspace…** (⇧⌘N) — pick or create a folder.
-- **File → Open Workspace…** (⇧⌘O) — open an existing workspace folder.
+- **File → New Workspace…** (⇧⌘N) — pick or create a folder. When the folder is brand-new, the current workspace's settings (LLM provider + API keys, embedding model, prompts, algorithm parameters) are copied into the new one so you don't have to reconfigure.
+- **File → Open Workspace…** (⇧⌘O) — open an existing workspace folder. No settings copy — the target's own settings are used.
 - **File → Open Recent Workspace** — last 10 workspaces.
 - **File → Reveal Workspace in Finder**.
-- **Settings → Workspace** — shows the active path and a Switch Workspace button.
+- **Settings → Workspace** — shows the active path, a **Switch Workspace…** button, and an **Open Default Workspace** button that returns to the legacy `~/Library/Application Support/NewsComb/` location.
 
 Switching workspaces relaunches the app so each workspace gets a clean process state. NewsComb refuses to switch while long-running jobs (knowledge graph processing, RSS refresh, OPML import, theme clustering, etc.) are in flight — wait for them to finish or cancel them first.
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -468,11 +468,20 @@ selections, prompts, algorithm parameters — everything the user customized.
   - `copyAppSettingsFromCurrent` returns `false` when target equals active.
   - `copyAppSettingsFromCurrent` succeeds end-to-end with a real value.
 
-**Known limitation (documented inline):** if the source workspace had a
-non-default `embedding_dimension`, the copied setting can mismatch the
-target's vec0 tables (which are sized at the seed-default dimension during
-migration). Brand-new workspaces have no embeddings yet, so the existing
-dimension-mismatch reset flow rebuilds the vec0 tables on first use.
+**Schema-state setting exclusion:** `active_embedding_dimension` is
+**not** copied. It tracks the dimension the target's vec0 virtual tables
+were physically created with — copying it from source would lie about
+on-disk schema and silently disable the rebuild path in
+`Database.migrate.createVec0Tables`. By leaving it untouched, the next
+migration after a workspace switch sees `active_embedding_dimension`
+(target's seeded value) ≠ `embedding_dimension` (copied from source),
+detects the mismatch, drops + recreates the vec0 tables at the right
+size, and updates `active_embedding_dimension` to match. **Result:
+settings and schema are guaranteed in agreement on first use.**
+
+The exclusion list lives in `WorkspaceCoordinator.nonPortableSettingKeys`.
+When future schema-state settings are added (e.g. a "tables_built_with"
+metadata key), append them there.
 
 **README** updated under the Workspaces section to mention that
 File → New Workspace inherits settings.

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -61,7 +61,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | 5 | MCP `X-Workspace` header | **done** | v2-ready wire protocol |
 | 6 | UI (File menu, window title, Settings, first-run sheet) | **done** | macOS only |
 | 7 | Test coverage sweep | **done** | fill gaps from prior phases |
-| 8 | Documentation (README, .mcp.json, CLAUDE.md) | pending | final commit |
+| 8 | Documentation (README, .mcp.json, CLAUDE.md) | **done** | final commit |
 
 ## Per-phase log
 
@@ -404,7 +404,26 @@ re-running. Not a workspace regression.
 
 ### Phase 8 — Documentation
 
-(pending)
+**Status:** complete.
+
+**Files modified:**
+- `README.md`:
+  - Added a top-level **Workspaces** section after First Launch:
+    layout, resolution order, UI commands, workspace-scoped vs app-global
+    settings.
+  - Updated **Setup for Claude Code** + **Setup for Claude Desktop** with
+    `--workspace` examples and the recommendation rationale.
+  - Updated **Prerequisites** to mention workspace alignment between bridge
+    arg and running app.
+- `.mcp.json`: added `--workspace` arg in the example so cloned-repo users
+  see the recommended pattern.
+- `CLAUDE.md`:
+  - Database section: `Database.shared` → `Database.current`, with a note
+    that the active DB can change across launches.
+  - New **Workspaces and settings scope** subsection — clarifies which
+    settings belong in `app_settings` (workspace-scoped) vs.
+    `WorkspaceDefaults` (app-global). Future Claude sessions touching
+    settings won't accidentally put them in the wrong place.
 
 ## Risks & open issues
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -57,7 +57,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | 1 | Foundation types (Workspace, WorkspaceCoordinator skeleton, WorkspaceDefaults) | **done** | new files only, no behavior change |
 | 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | **done** | mechanical |
 | 3 | App launch + legacy migration | **done** | wires bootstrap into `NewsCombApp.init` |
-| 4 | Workspace switch operation | pending | refuse-while-busy is core invariant |
+| 4 | Workspace switch operation | **done** | refuse-while-busy is core invariant; v1 ships as "stage + relaunch" |
 | 5 | MCP `X-Workspace` header | pending | v2-ready wire protocol |
 | 6 | UI (File menu, window title, Settings, first-run sheet) | pending | macOS only |
 | 7 | Test coverage sweep | pending | fill gaps from prior phases |
@@ -193,7 +193,44 @@ sanity check). SwiftLint clean (4 pre-existing warnings unchanged).
 
 ### Phase 4 — Workspace switch operation
 
-(pending)
+**Status:** complete. 9 unit tests, all green. SwiftLint clean.
+
+**Design decision:** rather than tear down `Database.current` and rebuild
+`MainViewModel` while SwiftUI views hold references (fragile), v1 ships as
+"stage + relaunch". `switchWorkspace(to:)` validates and persists; the UI
+relaunches the app, and Phase 3's `bootstrap()` resolves the new workspace
+cleanly. Same UX, dramatically less complexity.
+
+**Files modified:**
+- `NewsCombApp/Services/WorkspaceCoordinator.swift`:
+  - Added `busyReasonsProvider: () -> [String]` (injectable for tests).
+  - Added `var busyReasons: [String]` and `var canSwitchWorkspace: Bool`.
+  - Added `static func defaultBusyReasons()` that inspects `MainViewModel.shared`
+    for in-flight operations: hypergraph processing, RSS refresh, OPML import,
+    graph reset, graph simplification, node classification.
+  - Added `enum SwitchError: Error, LocalizedError, Equatable` with
+    `.busy(reasons:)` case.
+  - Added `switchWorkspace(to:) throws -> Workspace` — validates busy state,
+    persists target as last-opened, pushes to recents. **Does not relaunch.**
+
+**Files added:**
+- `NewsCombAppTests/WorkspaceCoordinatorSwitchTests.swift` (9 tests):
+  - Busy gating (true/false).
+  - Switch succeeds when not busy / refuses when busy / lists all reasons.
+  - Persists last-opened + pushes to recents.
+  - Does NOT change `active` or open the database (relaunch will).
+  - Error message formatting.
+
+**Deviations from plan:**
+- "Rebuild MainViewModel" became unnecessary because we relaunch instead.
+  Caller (Phase 6 UI) is responsible for the actual `NSApplication.terminate` +
+  `Process.run("open <bundle path>")` choreography.
+- `busyReasonsProvider` is injectable rather than hardcoded so tests don't
+  depend on `MainViewModel.shared` state.
+
+**Follow-ups:**
+- Phase 6: UI handles the relaunch choreography after `switchWorkspace(to:)`
+  succeeds. Show an alert with "busy because…" reasons when it throws.
 
 ### Phase 5 — MCP X-Workspace assertion
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -58,7 +58,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | **done** | mechanical |
 | 3 | App launch + legacy migration | **done** | wires bootstrap into `NewsCombApp.init` |
 | 4 | Workspace switch operation | **done** | refuse-while-busy is core invariant; v1 ships as "stage + relaunch" |
-| 5 | MCP `X-Workspace` header | pending | v2-ready wire protocol |
+| 5 | MCP `X-Workspace` header | **done** | v2-ready wire protocol |
 | 6 | UI (File menu, window title, Settings, first-run sheet) | pending | macOS only |
 | 7 | Test coverage sweep | pending | fill gaps from prior phases |
 | 8 | Documentation (README, .mcp.json, CLAUDE.md) | pending | final commit |
@@ -234,7 +234,49 @@ cleanly. Same UX, dramatically less complexity.
 
 ### Phase 5 — MCP X-Workspace assertion
 
-(pending)
+**Status:** complete. 14 unit tests, all green. Existing MCPToolTests still pass.
+
+**Files added:**
+- `NewsCombApp/MCP/MCPWorkspaceValidator.swift` — pure value-level validator.
+  `validate(requestedHeader:active:) -> ValidationFailure?` decides allow vs.
+  reject. Two failure cases: `.noActiveWorkspace(requested:)` and
+  `.mismatch(active:requested:)`. JSON-RPC error code -32001 (server-defined).
+
+**Files modified:**
+- `NewsCombApp/MCP/MCPHTTPServer.swift`:
+  - `dispatchRequest` checks the `X-Workspace` header before routing to a
+    transport. Mismatch → 400 Bad Request with a JSON-RPC error body.
+  - Added `validateWorkspaceHeader(_:)` (hops to MainActor for the active
+    workspace lookup).
+  - Added `static func makeJSONRPCErrorHTTPResponse(requestId:code:message:)` —
+    constructs HTTP/1.1 400 with JSON body, escapes quotes/backslashes.
+  - Added `static func extractRequestId(from:)` — extracts the JSON-RPC `id`
+    (string or int) from a request body.
+- `NewsCombMCPBridge/Sources/main.swift`:
+  - Parses `--workspace <path>` / `--workspace=<path>` from `CommandLine.arguments`.
+  - Falls back to `NEWSCOMB_WORKSPACE` env var.
+  - When set, sends `X-Workspace: <path>` on every POST so the app can assert.
+
+**Files added (tests):**
+- `NewsCombAppTests/MCPWorkspaceValidatorTests.swift` (14 tests):
+  - 4 allow-path tests (no header / empty / matching / matching-with-trailing-slash).
+  - 2 reject-path tests (no active workspace / mismatch).
+  - 3 message-formatting tests.
+  - 5 JSON-RPC response-formatting + ID-extraction tests.
+
+**Backward compatibility:** Bridges that don't send `X-Workspace` (older
+versions, manual curl, third-party clients) are accepted unchanged. Only
+explicit assertions are checked.
+
+**v2 readiness:** The wire protocol (`--workspace <path>` → `X-Workspace`
+header → server-side dispatch) is the same shape v2 will use for routing to
+multiple app processes by port. v1 only validates equality; v2 will add a
+discovery step. **No future config changes required for users.**
+
+**Follow-ups:**
+- Phase 6: surface a "MCP rejected" notification in the app UI when an
+  `X-Workspace` mismatch is logged (so the user knows to switch the workspace).
+- Phase 8: update `.mcp.json` examples to show `--workspace` arg.
 
 ### Phase 6 — UI
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -486,6 +486,27 @@ metadata key), append them there.
 **README** updated under the Workspaces section to mention that
 File → New Workspace inherits settings.
 
+### Enhancement B.1 — New workspace starts feed-empty
+
+A subtler issue surfaced after Enhancement B shipped: even though
+`copyAppSettings` doesn't touch `rss_source`, the target's `Database.init`
+runs `seedDefaultRSSSources` which inserts ~20 curated tech feeds. Worse,
+its only guard is "is `rss_source` empty?" — so deleting the seeded rows
+post-hoc would just trigger re-seeding on the next migrate.
+
+**Fix shipped:**
+- New `AppSettings.feedSeedSuppressed` key.
+- `Database.seedDefaultRSSSources` now early-returns when this flag is set.
+- `WorkspaceCoordinator.provisionNewWorkspace(at:)` composes
+  `copyAppSettings` + sets the suppression flag + deletes the seeded rows
+  in a single write transaction.
+- `WorkspaceCommands.attemptSwitch(copyIfNew: true)` now calls
+  `provisionNewWorkspace` instead of `copyAppSettingsFromCurrent`.
+- 5 new tests, including a reopen test that simulates the relaunch and
+  verifies the suppression flag survives a fresh migrate cycle.
+
+Result: a new workspace starts with zero feeds, even after relaunch.
+
 ## Risks & open issues
 
 - **MainViewModel rebuild on switch**: holds many SwiftUI bindings via

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -425,6 +425,58 @@ re-running. Not a workspace regression.
     `WorkspaceDefaults` (app-global). Future Claude sessions touching
     settings won't accidentally put them in the wrong place.
 
+## Post-v1 enhancements (shipped)
+
+### Enhancement A — Open Default Workspace button
+
+`WorkspaceSettingsSection` gained a third action button between "Reveal in
+Finder" and "Switch Workspace…": **Open Default Workspace** (house icon).
+Disabled when the active workspace already is `Workspace.legacyDirectory`,
+or when busy. Routes through the same `switchWorkspace` + relaunch flow.
+
+Refactor: pulled the alert/relaunch choreography out of the panel-driven
+path into a shared `attemptSwitch(to:)` helper so the new button reuses it.
+
+### Enhancement B — Copy app_settings on New Workspace
+
+When the user creates a new workspace via **File → New Workspace…**, all
+key/value rows in the current workspace's `app_settings` table are copied
+into the new workspace before relaunch. Carries over LLM keys, model
+selections, prompts, algorithm parameters — everything the user customized.
+
+**Files modified:**
+- `WorkspaceCoordinator.swift` — added `copyAppSettings(from:to:)` and the
+  convenience `copyAppSettingsFromCurrent(to:)`. Both open the source +
+  target databases transiently (so `Database.current` is unaffected) and
+  upsert source rows into target by key.
+- `WorkspaceCommands.swift` — `attemptSwitch(to:copyIfNew:)` calls
+  `copyAppSettingsFromCurrent` only when `copyIfNew == true` and the target
+  has no `newscomb.sqlite` yet. **File → New Workspace…** passes `true`;
+  **File → Open Workspace…** and **Open Recent** pass `false`. The Settings
+  pane's "Switch Workspace…" button has open-existing semantics — also
+  `false`. Failure during the copy aborts the switch (better than relaunching
+  with an unexpectedly-default workspace).
+
+**Files added:**
+- `WorkspaceCoordinatorCopySettingsTests.swift` (7 tests):
+  - Overwrites target seed defaults with source values.
+  - Carries source-only keys (e.g. `openrouter_key`) into target.
+  - Preserves target seed keys the source lacks (forward-compat with new
+    schema-seeded settings).
+  - Counts all source rows.
+  - `copyAppSettingsFromCurrent` returns `false` when no active workspace.
+  - `copyAppSettingsFromCurrent` returns `false` when target equals active.
+  - `copyAppSettingsFromCurrent` succeeds end-to-end with a real value.
+
+**Known limitation (documented inline):** if the source workspace had a
+non-default `embedding_dimension`, the copied setting can mismatch the
+target's vec0 tables (which are sized at the seed-default dimension during
+migration). Brand-new workspaces have no embeddings yet, so the existing
+dimension-mismatch reset flow rebuilds the vec0 tables on first use.
+
+**README** updated under the Workspaces section to mention that
+File → New Workspace inherits settings.
+
 ## Risks & open issues
 
 - **MainViewModel rebuild on switch**: holds many SwiftUI bindings via

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -59,7 +59,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | 3 | App launch + legacy migration | **done** | wires bootstrap into `NewsCombApp.init` |
 | 4 | Workspace switch operation | **done** | refuse-while-busy is core invariant; v1 ships as "stage + relaunch" |
 | 5 | MCP `X-Workspace` header | **done** | v2-ready wire protocol |
-| 6 | UI (File menu, window title, Settings, first-run sheet) | pending | macOS only |
+| 6 | UI (File menu, window title, Settings, first-run sheet) | **done** | macOS only |
 | 7 | Test coverage sweep | pending | fill gaps from prior phases |
 | 8 | Documentation (README, .mcp.json, CLAUDE.md) | pending | final commit |
 
@@ -280,7 +280,80 @@ discovery step. **No future config changes required for users.**
 
 ### Phase 6 — UI
 
-(pending)
+**Status:** complete. Build clean. SwiftLint clean. New observable-recents
+tests added; full workspace suite (~50 tests) green.
+
+**Files added:**
+- `NewsCombApp/Views/WorkspaceRelauncher.swift` — wraps the standard macOS
+  app-relaunch pattern (spawn `/bin/sh -c "sleep 0.4 && open <bundle>"`,
+  then `NSApplication.shared.terminate(nil)`).
+- `NewsCombApp/Views/WorkspaceCommands.swift` — `Commands` provider injected
+  via `.commands { … }` on the main `WindowGroup`. Adds File-menu items
+  (after `.newItem`):
+  - **New Workspace…** (⇧⌘N) — `NSOpenPanel` with `canCreateDirectories`.
+  - **Open Workspace…** (⇧⌘O) — `NSOpenPanel` directories-only.
+  - **Open Recent Workspace ▸** — submenu populated from
+    `coordinator.recentWorkspaces` (auto-disabled when empty); includes
+    "Clear Menu".
+  - **Reveal Workspace in Finder** — disabled when no active workspace.
+  Each switch attempt routes through `coordinator.switchWorkspace(to:)` and,
+  on success, prompts an `NSAlert` with Relaunch/Cancel before calling
+  `WorkspaceRelauncher.relaunchApp()`. Refused-while-busy errors surface as
+  a warning alert with the human-readable reason list.
+- `NewsCombApp/Views/WorkspaceSettingsSection.swift` — `Section` for the
+  Settings `Form`. Shows active workspace name + path (monospaced,
+  selectable, truncated middle). Buttons: Reveal in Finder, Switch
+  Workspace…. Disabled-with-explanation when `busyReasons` is non-empty.
+- `NewsCombApp/Views/FirstRunWorkspaceSheet.swift` — sheet shown when
+  `coordinator.active == nil`. Two prominent buttons (Create New / Open
+  Existing) plus an inline list of up to 5 recent workspaces. Default folder
+  for the create panel is `~/Documents/NewsComb-Workspaces/`.
+- `interactiveDismissDisabled(true)` — the user can't accidentally dismiss
+  the first-run sheet without picking a workspace.
+
+**Files modified:**
+- `NewsCombApp/Services/WorkspaceCoordinator.swift`:
+  - Added observable `recentWorkspaces: [URL]` synced from `WorkspaceDefaults`
+    after each push/remove. SwiftUI menus + the first-run list track this.
+  - Added `removeRecent(_:)` — used by the "Clear Menu" item.
+- `NewsCombApp/NewsCombApp.swift`:
+  - Attached `.commands { WorkspaceCommands(...) }` to the main `WindowGroup`
+    (wrapped in its own `#if os(macOS)` because mixing modifiers and new
+    scenes inside a single `#if` confuses the scene builder).
+- `NewsCombApp/Views/ContentView.swift`:
+  - Reads `WorkspaceCoordinator.shared`. Sets `.navigationTitle` to
+    "NewsComb — &lt;workspace name&gt;" or just "NewsComb".
+  - Presents `FirstRunWorkspaceSheet` via a `Binding(get:set:)` driven by
+    `coordinator.active == nil`; the sheet self-dismisses when the user
+    picks a workspace and `openWorkspace(at:)` flips active to non-nil.
+- `NewsCombApp/Views/SettingsView.swift`:
+  - Inserts `WorkspaceSettingsSection` at the top of the Form (macOS only).
+
+**Test coverage added in Phase 6:**
+- `WorkspaceCoordinatorTests.testRecentWorkspacesInitiallyMatchesDefaults`
+- `WorkspaceCoordinatorTests.testRecordActiveUpdatesObservedRecents`
+- `WorkspaceCoordinatorTests.testRemoveRecentUpdatesObservedList`
+
+**Deviations from plan:**
+- The relauncher is a separate file (`WorkspaceRelauncher.swift`) rather
+  than living inside the coordinator. Keeps the coordinator AppKit-free
+  and unit-testable from any platform.
+- File-menu items are placed under `CommandGroup(after: .newItem)` so they
+  group naturally with macOS's existing File-menu items.
+- Window title uses `.navigationTitle(...)` on `ContentView` rather than a
+  per-`WindowGroup` static title, since the workspace name is dynamic.
+
+**Manual smoke test deferred:** the app couldn't be launched safely from
+this session (would bind port 63548 and open windows). A real launch should
+verify: (a) bare launch with no workspace shows the first-run sheet;
+(b) File → New Workspace creates a folder + opens it; (c) Switch Workspace
+prompts relaunch and reopens with the new DB; (d) menu greys out when
+nothing's active.
+
+**Follow-ups:**
+- Phase 7: add a smoke test or UI test that exercises the first-run sheet
+  binding logic if practical.
+- Phase 8: docs.
 
 ### Phase 7 — Test coverage sweep
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -1,0 +1,144 @@
+# Workspaces — Implementation Plan
+
+Branch: `feature/workspaces`
+Started: 2026-04-28
+Status: in progress
+
+## Goal
+
+Allow NewsComb to work on multiple independent SQLite knowledge bases. A
+**workspace** is a directory containing `newscomb.sqlite` (and any side
+artifacts). The user picks which workspace the app is using; the same
+SwiftUI app + same MCP server target whichever workspace is currently
+active.
+
+## Non-goals (v1)
+
+- Running multiple NewsComb processes concurrently, each on its own
+  workspace. Postponed to v2. The wire protocol is designed v2-ready
+  (see Phase 5) so users won't need to change MCP config when v2 ships.
+
+## Decisions
+
+- **Recent workspaces**: last 10, stored in `UserDefaults`.
+- **Default workspace location**: `~/Documents/NewsComb-Workspaces/`.
+- **Switching while jobs are running**: refuse. User cancels or quits.
+- **Legacy DB at `~/Library/Application Support/NewsComb/newscomb.sqlite`**:
+  left in place; the parent directory becomes the "Default" workspace on
+  first launch after upgrade.
+- **Settings split**:
+  - Workspace-scoped → existing `app_settings` table inside each DB.
+  - App-global → `UserDefaults`: `lastOpenedWorkspace`, `recentWorkspaces`.
+- **Database accessor**: `Database.current` (mutable, workspace-aware).
+  Old `Database.shared` is removed; ~55 call sites renamed mechanically.
+- **MCP**: bridge accepts `--workspace <dir>` and sends an `X-Workspace`
+  header. App rejects mismatched headers with a JSON-RPC error (single
+  active workspace at a time in v1).
+
+## Architecture sketch
+
+```
+NewsCombApp.init
+    ↓
+WorkspaceCoordinator.bootstrap
+    ↓ (resolves: --workspace arg | env | UserDefaults | legacy | picker)
+    ↓
+WorkspaceCoordinator.active = Workspace(directory: …)
+    │
+    ├─ Database.current  ← reads from coordinator
+    ├─ MainViewModel     ← rebuilt on switch
+    └─ MCPServerService  ← unchanged port; checks X-Workspace header
+```
+
+## Phases
+
+| # | Title | Status | Notes |
+|---|-------|--------|-------|
+| 1 | Foundation types (Workspace, WorkspaceCoordinator skeleton, WorkspaceDefaults) | **done** | new files only, no behavior change |
+| 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | pending | mechanical |
+| 3 | App launch + legacy migration | pending | wires bootstrap into `NewsCombApp.init` |
+| 4 | Workspace switch operation | pending | refuse-while-busy is core invariant |
+| 5 | MCP `X-Workspace` header | pending | v2-ready wire protocol |
+| 6 | UI (File menu, window title, Settings, first-run sheet) | pending | macOS only |
+| 7 | Test coverage sweep | pending | fill gaps from prior phases |
+| 8 | Documentation (README, .mcp.json, CLAUDE.md) | pending | final commit |
+
+## Per-phase log
+
+Each phase adds an entry below with: scope as executed, files
+touched, tests added, deviations from plan, and follow-ups.
+
+### Phase 1 — Foundation types
+
+**Status:** complete. 21 unit tests, all green. SwiftLint clean.
+
+**Files added:**
+- `NewsCombApp/Models/Workspace.swift` — value type (directory URL + helpers).
+  Includes a top-level internal `URL.canonicalDirectoryURL` helper that
+  standardizes and strips trailing `/` so `/tmp/Foo` and `/tmp/Foo/` are equal.
+- `NewsCombApp/Services/WorkspaceDefaults.swift` — `UserDefaults` wrapper.
+  `lastOpenedWorkspace` (single URL) and `recentWorkspaces` ([URL], capped at 10).
+  Tests use a per-test `UserDefaults(suiteName:)` to avoid polluting `.standard`.
+- `NewsCombApp/Services/WorkspaceCoordinator.swift` — `@MainActor @Observable`.
+  `setActive(_:)` records active + persists last-opened + pushes to recents.
+  Phase 2/3/4 will add Database wiring, bootstrap, and switchTo respectively.
+- `NewsCombAppTests/WorkspaceTests.swift` (7 tests)
+- `NewsCombAppTests/WorkspaceDefaultsTests.swift` (9 tests)
+- `NewsCombAppTests/WorkspaceCoordinatorTests.swift` (5 tests)
+
+**Deviations from plan:**
+- `WorkspaceDefaults` is `@unchecked Sendable` (UserDefaults isn't Sendable in
+  Swift 6, but is documented thread-safe). Acceptable for an injection-friendly
+  wrapper held by the `@MainActor` coordinator.
+- Added a `URL.canonicalDirectoryURL` extension (not in the original plan) once
+  trailing-slash equality bit two tests. Used in both `Workspace` init and the
+  defaults getters/setters/dedup helpers so canonicalization happens in exactly
+  one place.
+
+**Follow-ups for later phases:**
+- Phase 2: `WorkspaceCoordinator` will gain a `database: Database` field;
+  `setActive(_:)` will need a Database parameter or build one internally.
+- Phase 4: `setActive(_:)` is currently the only state-change entry. Phase 4's
+  `switchTo(_:)` should route through it (or supersede it) so recents/last-opened
+  bookkeeping isn't duplicated.
+
+### Phase 2 — Database refactor
+
+(pending)
+
+### Phase 3 — App launch + legacy migration
+
+(pending)
+
+### Phase 4 — Workspace switch operation
+
+(pending)
+
+### Phase 5 — MCP X-Workspace assertion
+
+(pending)
+
+### Phase 6 — UI
+
+(pending)
+
+### Phase 7 — Test coverage sweep
+
+(pending)
+
+### Phase 8 — Documentation
+
+(pending)
+
+## Risks & open issues
+
+- **MainViewModel rebuild on switch**: holds many SwiftUI bindings via
+  `@Observable`. Rebuilding may briefly invalidate active views. Plan:
+  switch happens via a coordinator that the views observe; views should
+  re-bind to the new VM through environment injection.
+- **Embedding model dimension across workspaces**: NomicEmbeddingService
+  is process-wide; if two workspaces use different dimensions, the cached
+  model is wrong. v1 mitigation: warn the user; lazy-reload on dimension
+  mismatch.
+- **In-flight MCP requests during switch**: handled by refuse-while-busy
+  invariant — busy state includes pending MCP work.

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -60,7 +60,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | 4 | Workspace switch operation | **done** | refuse-while-busy is core invariant; v1 ships as "stage + relaunch" |
 | 5 | MCP `X-Workspace` header | **done** | v2-ready wire protocol |
 | 6 | UI (File menu, window title, Settings, first-run sheet) | **done** | macOS only |
-| 7 | Test coverage sweep | pending | fill gaps from prior phases |
+| 7 | Test coverage sweep | **done** | fill gaps from prior phases |
 | 8 | Documentation (README, .mcp.json, CLAUDE.md) | pending | final commit |
 
 ## Per-phase log
@@ -357,7 +357,50 @@ nothing's active.
 
 ### Phase 7 — Test coverage sweep
 
-(pending)
+**Status:** complete. **530 tests passing**, 71 of them new for the
+workspace feature across 7 files. The single remaining failure
+(`OasisEnvironmentServiceTests.testPersonaNodeTypes_containsExpectedTypes`)
+is **pre-existing on `main`** — verified by checking out `main` and
+re-running. Not a workspace regression.
+
+**Files added:**
+- `NewsCombAppTests/DatabaseWorkspaceInitTests.swift` (7 tests):
+  - `init(directory:)` creates the directory tree if absent.
+  - `init(directory:)` creates the `newscomb.sqlite` file.
+  - `init(directory:)` runs migrations — verified by spot-checking 5 core
+    tables via `sqlite_master`.
+  - `workspaceDirectory` is canonicalized (trailing slash stripped).
+  - Two `Database` instances at different paths are independent.
+  - `setCurrent(_:)` replaces the active reference.
+  - `resetCurrentForTesting()` clears active without crashing on
+    subsequent `setCurrent`.
+
+**Coverage by phase (cumulative):**
+| Phase | New tests |
+|-------|-----------|
+| 1 | 21 |
+| 2 | +3 |
+| 3 | +12 |
+| 4 | +9 |
+| 5 | +14 |
+| 6 | +3 |
+| 7 | +7 |
+| **Total new** | **69** |
+
+**Gaps NOT covered (intentionally):**
+- UI layer (commands menu items, sheet presentation): would require
+  XCUITest infrastructure that doesn't exist in the project. Manual smoke
+  test deferred — see Phase 6 follow-ups.
+- The relauncher itself (`Process.run` + `NSApplication.terminate`): can't
+  be unit-tested without killing the test runner.
+- Live MCP HTTP server reject path: tested via the pure validator + the
+  HTTP-response builder; an end-to-end TCP test would add value but
+  requires standing up a real port.
+
+**Pre-existing failure (out of scope):**
+- `OasisEnvironmentServiceTests.testPersonaNodeTypes_containsExpectedTypes`
+  fails on both `main` and `feature/workspaces`. Out of scope for the
+  workspace feature.
 
 ### Phase 8 — Documentation
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -56,7 +56,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 |---|-------|--------|-------|
 | 1 | Foundation types (Workspace, WorkspaceCoordinator skeleton, WorkspaceDefaults) | **done** | new files only, no behavior change |
 | 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | **done** | mechanical |
-| 3 | App launch + legacy migration | pending | wires bootstrap into `NewsCombApp.init` |
+| 3 | App launch + legacy migration | **done** | wires bootstrap into `NewsCombApp.init` |
 | 4 | Workspace switch operation | pending | refuse-while-busy is core invariant |
 | 5 | MCP `X-Workspace` header | pending | v2-ready wire protocol |
 | 6 | UI (File menu, window title, Settings, first-run sheet) | pending | macOS only |
@@ -149,7 +149,47 @@ sanity check). SwiftLint clean (4 pre-existing warnings unchanged).
 
 ### Phase 3 — App launch + legacy migration
 
-(pending)
+**Status:** complete. 12 new bootstrap unit tests, all green. SwiftLint clean.
+
+**Files modified:**
+- `NewsCombApp/Services/WorkspaceCoordinator.swift`:
+  - Added `BootstrapSource` enum (commandLine / environment / lastOpened / legacy).
+  - Added `BootstrapResult` enum (`opened(Workspace, source:)` / `needsSelection`).
+  - Added `bootstrap(commandLineArgs:environment:legacyDirectory:fileManager:) throws -> BootstrapResult`
+    with full dependency injection for testability.
+  - Added `static func parseWorkspaceArg(from:)` — handles
+    `--workspace <value>` and `--workspace=<value>` forms; rejects empty values.
+- `NewsCombApp/NewsCombApp.swift`:
+  - Replaced `_ = Database.current` with `try WorkspaceCoordinator.shared.bootstrap()`.
+  - Logs the bootstrap source (CLI / env / lastOpened / legacy) on success.
+  - Catches explicit-source failures and logs them. Falls through to the
+    `Database.current` lazy fallback (Phase 6 will surface errors in the UI).
+
+**Files added:**
+- `NewsCombAppTests/WorkspaceCoordinatorBootstrapTests.swift` (12 tests):
+  - 6 tests for `parseWorkspaceArg` (space form, equals form, missing, empty, etc.)
+  - 6 tests for `bootstrap` resolution priority + sources + fall-through.
+
+**Resolution priority:**
+1. `--workspace <path>` CLI arg — explicit, errors propagate.
+2. `NEWSCOMB_WORKSPACE` env var — explicit, errors propagate.
+3. `WorkspaceDefaults.lastOpenedWorkspace` — implicit, falls through if dir missing.
+4. Legacy `~/Library/Application Support/NewsComb/newscomb.sqlite` — implicit.
+5. Returns `.needsSelection` — UI handles in Phase 6.
+
+**Deviations from plan:**
+- Made `legacyDirectory` an injectable parameter on `bootstrap` rather than
+  a hardcoded reference to `Workspace.legacyDirectory`. Lets tests simulate
+  legacy detection without touching the user's actual Application Support dir.
+- Implicit-source failures (deleted lastOpened directory, broken legacy DB)
+  log + fall through rather than throwing. Explicit-source failures throw —
+  user-supplied bad input should fail loudly.
+
+**Follow-ups for later phases:**
+- Phase 4: `switchWorkspace(to:)` reuses `openWorkspace(at:)` + `Database.setCurrent`.
+  Adds refuse-while-busy and tear-down semantics.
+- Phase 6: capture bootstrap errors in coordinator state for UI display.
+  Show first-run picker when bootstrap returns `.needsSelection`.
 
 ### Phase 4 — Workspace switch operation
 

--- a/WORKSPACE_PLAN.md
+++ b/WORKSPACE_PLAN.md
@@ -55,7 +55,7 @@ WorkspaceCoordinator.active = Workspace(directory: …)
 | # | Title | Status | Notes |
 |---|-------|--------|-------|
 | 1 | Foundation types (Workspace, WorkspaceCoordinator skeleton, WorkspaceDefaults) | **done** | new files only, no behavior change |
-| 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | pending | mechanical |
+| 2 | Database refactor (`init(directory:)`, `Database.current`, rename ~55 sites) | **done** | mechanical |
 | 3 | App launch + legacy migration | pending | wires bootstrap into `NewsCombApp.init` |
 | 4 | Workspace switch operation | pending | refuse-while-busy is core invariant |
 | 5 | MCP `X-Workspace` header | pending | v2-ready wire protocol |
@@ -104,7 +104,48 @@ touched, tests added, deviations from plan, and follow-ups.
 
 ### Phase 2 — Database refactor
 
-(pending)
+**Status:** complete. 24 unit tests green (incl. DB-touching DeleteSourceGRDBTests
+sanity check). SwiftLint clean (4 pre-existing warnings unchanged).
+
+**Files modified:**
+- `NewsCombApp/Services/DatabaseService.swift`:
+  - Removed `static let shared`, removed `private init()`.
+  - Added `public init(directory: URL) throws` — opens
+    `<directory>/newscomb.sqlite`, runs migrations.
+  - Added `public let workspaceDirectory: URL` (canonicalized) for callers
+    that need to know which workspace they're talking to.
+  - Added `private static let active = Mutex<Database?>(nil)` (Synchronization.Mutex).
+  - Added `public static var current: Database` — lazy-bootstraps to
+    `Workspace.legacyDirectory` if `setCurrent(_:)` hasn't been called yet.
+    This is the **transitional** path that keeps existing code working until
+    Phase 3 wires explicit bootstrap.
+  - Added `public static func setCurrent(_:)` and `static func resetCurrentForTesting()`.
+- `NewsCombApp/Services/WorkspaceCoordinator.swift`:
+  - `setActive(_:)` (Phase 1) split into two:
+    - `recordActive(_:)` — bookkeeping only (no I/O), useful for tests.
+    - `openWorkspace(at:) throws -> Workspace` — builds Database, calls
+      `Database.setCurrent`, then `recordActive`.
+- 49 files: mechanical rename `Database.shared` → `Database.current` via sed.
+  64 occurrences across 57 files now reference `current`. 0 `shared` remain.
+
+**Phase 1 test updates:**
+- `WorkspaceCoordinatorTests` — split into two groups:
+  - bookkeeping (uses `recordActive`, no DB I/O)
+  - real I/O (uses `openWorkspace` against a per-test temp directory; cleaned
+    up in `tearDown` along with `Database.resetCurrentForTesting()`)
+
+**Deviations from plan:**
+- Renamed `setActive` → `recordActive` to clarify it's the internal bookkeeping
+  helper. The new public API is `openWorkspace(at:)`.
+- Used `Synchronization.Mutex` (already in use elsewhere — `MCPHTTPServer`)
+  instead of an actor or `nonisolated(unsafe)`. Cleanest fit for a
+  cross-actor singleton accessor.
+
+**Follow-ups for later phases:**
+- Phase 3: replace lazy-bootstrap fallback in `Database.current` with a
+  `fatalError` once `bootstrap()` always runs at app launch.
+- Phase 4: `switchWorkspace(to:)` should refuse-while-busy, then call
+  `openWorkspace(at:)`, and tear down the old DB.
 
 ### Phase 3 — App launch + legacy migration
 


### PR DESCRIPTION
## Summary

- Adds a **Workspace** concept so NewsComb can work on multiple independent knowledge bases (e.g. Tech vs. Confluence). A workspace is a folder containing `newscomb.sqlite`. Switching is **stage-and-relaunch** — the new workspace starts from a clean process state. Refused while long-running jobs are in flight.
- The MCP bridge accepts `--workspace <path>` (or `NEWSCOMB_WORKSPACE` env) and sends an `X-Workspace` header. The app rejects mismatched headers with a JSON-RPC error so a Claude Code session in folder A can't accidentally talk to a NewsComb running on folder B's workspace. Wire protocol is v2-ready (multi-instance was deferred at the user's request; users won't need to update `.mcp.json` when v2 ships).
- File menu, window title, Settings section, and a first-run picker are wired up. **File → New Workspace…** copies portable settings (LLM keys, prompts, algorithm params) but starts feed-empty. Schema-state keys (`active_embedding_dimension`) are deliberately excluded so the next migrate rebuilds vec0 tables to match the copied embedding dimension.

See `WORKSPACE_PLAN.md` for the per-phase breakdown, design rationale, and follow-ups.

**Stats:** 12 commits, 80 files, +2842/-87. **82 new workspace tests** across 9 files; full suite reports 543 passing. The single remaining `OasisEnvironmentServiceTests` failure pre-existed on `main` and is unrelated.

## Test plan

- [ ] Bare launch with no `--workspace` and no last-opened: first-run sheet appears with Create / Open buttons.
- [ ] **File → New Workspace…** (⇧⌘N): creates a folder under `~/Documents/NewsComb-Workspaces/`, opens it, copies settings, leaves feeds empty.
- [ ] **File → Open Workspace…** (⇧⌘O): opens an existing folder, no settings copy.
- [ ] **File → Open Recent Workspace**: shows the last 10 workspaces.
- [ ] **File → Reveal Workspace in Finder**.
- [ ] **Settings → Workspace** shows path, *Open Default Workspace* button (returns to legacy `~/Library/Application Support/NewsComb/`), and *Switch Workspace…* button.
- [ ] Switching workspaces relaunches NewsComb and reopens on the new DB.
- [ ] Refuse-while-busy: start a hypergraph processing job, attempt to switch — alert lists in-flight reasons; switch blocked.
- [ ] MCP from a different workspace: bridge with `--workspace /wrong/path` produces a JSON-RPC error mentioning the active and requested paths.
- [ ] MCP without `--workspace`: works unchanged (backward compat).
- [ ] Existing install upgrade: app opens the legacy `~/Library/Application Support/NewsComb/newscomb.sqlite` automatically (legacy detection); UserDefaults remembers it as last-opened.
- [ ] After **New Workspace…** with embedding dim differing from default: vec0 tables rebuilt on relaunch (no manual reset prompt because new workspace has no embeddings yet).