### PR TITLE
MCP: ingest articles via manual feeds + signing + workspace polish

### DIFF
--- a/NewsCombApp.xcodeproj/project.pbxproj
+++ b/NewsCombApp.xcodeproj/project.pbxproj
@@ -498,10 +498,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = NewsCombApp/NewsComb.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6CGNH3LTV7;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
@@ -519,6 +520,7 @@
 				INFOPLIST_FILE = NewsCombApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NewsComb;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
+				INFOPLIST_KEY_NSDocumentsFolderUsageDescription = "NewsComb would like to save its knowledge base in your Documents folder";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025. All rights reserved.";
 				INFOPLIST_KEY_NSMainStoryboardFile = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
@@ -540,10 +542,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = NewsCombApp/NewsComb.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6CGNH3LTV7;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
@@ -561,6 +564,7 @@
 				INFOPLIST_FILE = NewsCombApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NewsComb;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
+				INFOPLIST_KEY_NSDocumentsFolderUsageDescription = "NewsComb would like to save its knowledge base in your Documents folder";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025. All rights reserved.";
 				INFOPLIST_KEY_NSMainStoryboardFile = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;

--- a/NewsCombApp/Info.plist
+++ b/NewsCombApp/Info.plist
@@ -2,36 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.news</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025. All rights reserved.</string>
-	<key>NSMainStoryboardFile</key>
-	<string></string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/NewsCombApp/MCP/MCPAppCoordinator.swift
+++ b/NewsCombApp/MCP/MCPAppCoordinator.swift
@@ -40,6 +40,78 @@ final class MCPAppCoordinator {
         }
     }
 
+    // MARK: - Article ingestion (manual feeds)
+
+    /// Creates a manual feed (synthetic-URL `rss_source`) so MCP-supplied
+    /// articles have a parent container.
+    func createManualFeed(title: String) -> String {
+        logger.info("MCP triggered createManualFeed title=\(title, privacy: .public)")
+        let service = ArticleIngestionService()
+        do {
+            let source = try service.createManualFeed(title: title)
+            mainViewModel.loadSources()
+            let id = source.id ?? -1
+            return "Created manual feed #\(id): '\(source.title ?? "")'. Use ingest_article with source_id=\(id) to add articles."
+        } catch let error as ArticleIngestionService.IngestionError {
+            return "Create manual feed failed: \(error.localizedDescription)"
+        } catch {
+            return "Create manual feed failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Inserts an MCP-supplied article into an existing manual feed.
+    func ingestArticle(
+        sourceId: Int64,
+        title: String,
+        body: String,
+        link: String?,
+        author: String?,
+        pubDate: Date?,
+        guid: String?
+    ) -> String {
+        logger.info("MCP triggered ingestArticle sourceId=\(sourceId, privacy: .public) title=\(title, privacy: .public)")
+        let service = ArticleIngestionService()
+        do {
+            let item = try service.ingestArticle(
+                sourceId: sourceId,
+                title: title,
+                body: body,
+                link: link,
+                author: author,
+                pubDate: pubDate,
+                guid: guid
+            )
+            mainViewModel.loadSources()
+            let id = item.id ?? -1
+            return "Ingested article #\(id) into feed #\(sourceId): '\(item.title)' (\(item.fullContent?.count ?? 0) chars)."
+        } catch let error as ArticleIngestionService.IngestionError {
+            return "Ingest article failed: \(error.localizedDescription)"
+        } catch {
+            return "Ingest article failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Re-fetches `full_content` for a single article via the Postlight pipeline.
+    func refreshArticle(feedItemId: Int64) async -> String {
+        logger.info("MCP triggered refreshArticle feedItemId=\(feedItemId, privacy: .public)")
+        let service = ArticleIngestionService()
+        do {
+            let outcome = try await service.refreshArticle(feedItemId: feedItemId)
+            mainViewModel.loadSources()
+            let delta = outcome.contentLengthDelta
+            let sign = delta >= 0 ? "+" : ""
+            var msg = "Refreshed article #\(outcome.feedItemId): \(outcome.previousContentLength) → \(outcome.newContentLength) chars (\(sign)\(delta))."
+            if outcome.linkChanged {
+                msg += " Link redirected to \(outcome.newLink)."
+            }
+            return msg
+        } catch let error as ArticleIngestionService.IngestionError {
+            return "Refresh article failed: \(error.localizedDescription)"
+        } catch {
+            return "Refresh article failed: \(error.localizedDescription)"
+        }
+    }
+
     // MARK: - Knowledge graph processing
 
     /// Triggers the same action as the "Process Knowledge Graph" toolbar button.

--- a/NewsCombApp/MCP/MCPToolDispatcher.swift
+++ b/NewsCombApp/MCP/MCPToolDispatcher.swift
@@ -40,6 +40,12 @@ enum MCPToolDispatcher {
                 result = try await MCPQueryKnowledgeGraphTool.run(arguments: arguments)
             case "refresh_feeds":
                 result = await MCPRefreshFeedsTool.run(arguments: arguments)
+            case "create_manual_feed":
+                result = try await MCPCreateManualFeedTool.run(arguments: arguments)
+            case "ingest_article":
+                result = try await MCPIngestArticleTool.run(arguments: arguments)
+            case "refresh_article":
+                result = try await MCPRefreshArticleTool.run(arguments: arguments)
             case "process_knowledge_graph":
                 result = await MCPProcessKnowledgeGraphTool.run(arguments: arguments)
             case "cancel_knowledge_graph_processing":

--- a/NewsCombApp/MCP/MCPToolHandler.swift
+++ b/NewsCombApp/MCP/MCPToolHandler.swift
@@ -167,6 +167,75 @@ struct MCPToolHandler: Sendable {
                 annotations: .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true)
             ),
             Tool(
+                name: "create_manual_feed",
+                description: "Create a 'manual' feed — a container for articles ingested directly via MCP (e.g. when no RSS source exists). The feed is stored as an rss_source row with a synthetic 'manual:' URL that the regular RSS refresh path skips. Use the returned source_id with ingest_article.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "title": .object([
+                            "type": .string("string"),
+                            "description": .string("Human-readable feed title shown in the UI.")
+                        ])
+                    ]),
+                    "required": .array([.string("title")])
+                ]),
+                annotations: .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false)
+            ),
+            Tool(
+                name: "ingest_article",
+                description: "Ingest a single article into an existing manual feed. Body is stored as full_content. Re-calling with the same (source_id, guid) — or same source_id and link, when guid is omitted — updates the existing row instead of creating a duplicate. Refuses to ingest into real RSS feeds.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "source_id": .object([
+                            "type": .string("integer"),
+                            "description": .string("ID of the manual feed (returned by create_manual_feed).")
+                        ]),
+                        "title": .object([
+                            "type": .string("string"),
+                            "description": .string("Article title.")
+                        ]),
+                        "body": .object([
+                            "type": .string("string"),
+                            "description": .string("Full article text (Markdown or plain text). Minimum 100 chars after trimming.")
+                        ]),
+                        "link": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional canonical URL. When omitted, a synthetic 'manual:item:<uuid>' is generated. Used as the dedup key when guid is not provided.")
+                        ]),
+                        "author": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional author name.")
+                        ]),
+                        "pub_date": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional publication date as ISO8601 (e.g. 2026-04-29T12:00:00Z).")
+                        ]),
+                        "guid": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional explicit GUID. Defaults to link. Determines upsert behavior under (source_id, guid).")
+                        ])
+                    ]),
+                    "required": .array([.string("source_id"), .string("title"), .string("body")])
+                ]),
+                annotations: .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false)
+            ),
+            Tool(
+                name: "refresh_article",
+                description: "Re-fetch full_content for a single article from its link, independently of the parent feed. Uses the same Postlight extraction pipeline as the RSS refresh. Updates the link if the page now redirects elsewhere. Rejects articles whose link scheme is not http(s) (e.g. manually-composed articles with no real source URL).",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "feed_item_id": .object([
+                            "type": .string("integer"),
+                            "description": .string("ID of the article to refresh (from get_recent_articles or feed_item.id).")
+                        ])
+                    ]),
+                    "required": .array([.string("feed_item_id")])
+                ]),
+                annotations: .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true)
+            ),
+            Tool(
                 name: "process_knowledge_graph",
                 description: "Trigger LLM extraction over unprocessed articles — equivalent to the 'Process Knowledge Graph' toolbar button. Persists new entities, relationships, embeddings, and auto-simplifies the graph. The UI shows live progress.",
                 inputSchema: .object([

--- a/NewsCombApp/MCP/Tools/MCPCreateManualFeedTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPCreateManualFeedTool.swift
@@ -1,0 +1,14 @@
+import Foundation
+import MCP
+
+/// Creates a "manual" feed — an `rss_source` row with a synthetic URL that
+/// the regular RSS refresh path skips. Acts as a container for articles
+/// ingested via `ingest_article`.
+enum MCPCreateManualFeedTool {
+    static func run(arguments: [String: Value]) async throws -> String {
+        guard let title = arguments["title"]?.stringValue, !title.isEmpty else {
+            throw MCPToolError.missingParameter("title")
+        }
+        return await MCPAppCoordinator.shared.createManualFeed(title: title)
+    }
+}

--- a/NewsCombApp/MCP/Tools/MCPIngestArticleTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPIngestArticleTool.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MCP
+
+/// Ingests an MCP-supplied article into a manual feed. The body becomes the
+/// stored `full_content`; optional `link`, `author`, `pub_date`, and `guid`
+/// fields are passed through. Re-ingesting the same `(source_id, guid)`
+/// updates the existing row instead of duplicating.
+enum MCPIngestArticleTool {
+    static func run(arguments: [String: Value]) async throws -> String {
+        guard let sourceId = arguments["source_id"]?.intValue.map(Int64.init) else {
+            throw MCPToolError.missingParameter("source_id")
+        }
+        guard let title = arguments["title"]?.stringValue, !title.isEmpty else {
+            throw MCPToolError.missingParameter("title")
+        }
+        guard let body = arguments["body"]?.stringValue, !body.isEmpty else {
+            throw MCPToolError.missingParameter("body")
+        }
+
+        let link = arguments["link"]?.stringValue
+        let author = arguments["author"]?.stringValue
+        let guid = arguments["guid"]?.stringValue
+
+        let pubDate: Date?
+        if let raw = arguments["pub_date"]?.stringValue, !raw.isEmpty {
+            guard let parsed = parseISO8601(raw) else {
+                throw MCPToolError.invalidParameter("pub_date", detail: "expected ISO8601 (e.g. 2026-04-29T12:00:00Z), got '\(raw)'")
+            }
+            pubDate = parsed
+        } else {
+            pubDate = nil
+        }
+
+        return await MCPAppCoordinator.shared.ingestArticle(
+            sourceId: sourceId,
+            title: title,
+            body: body,
+            link: link,
+            author: author,
+            pubDate: pubDate,
+            guid: guid
+        )
+    }
+
+    private static func parseISO8601(_ string: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFractional.date(from: string) { return date }
+
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: string)
+    }
+}

--- a/NewsCombApp/MCP/Tools/MCPRefreshArticleTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPRefreshArticleTool.swift
@@ -1,0 +1,14 @@
+import Foundation
+import MCP
+
+/// Re-fetches an individual article's `full_content` from its `link` via the
+/// same Postlight extraction pipeline the RSS path uses, independently of
+/// any feed-level refresh.
+enum MCPRefreshArticleTool {
+    static func run(arguments: [String: Value]) async throws -> String {
+        guard let feedItemId = arguments["feed_item_id"]?.intValue.map(Int64.init) else {
+            throw MCPToolError.missingParameter("feed_item_id")
+        }
+        return await MCPAppCoordinator.shared.refreshArticle(feedItemId: feedItemId)
+    }
+}

--- a/NewsCombApp/Models/AppSettings.swift
+++ b/NewsCombApp/Models/AppSettings.swift
@@ -47,13 +47,6 @@ extension AppSettings {
     /// Used to detect when tables need to be recreated after a dimension change.
     static let activeEmbeddingDimension = "active_embedding_dimension"
 
-    /// When set to "1", suppresses the default-RSS-feed seeding logic in
-    /// `Database.seedDefaultRSSSources`. Used by
-    /// `WorkspaceCoordinator.provisionNewWorkspace` to keep a freshly-created
-    /// workspace empty of feeds — the user picks feeds appropriate to the
-    /// new domain rather than inheriting the curated tech list.
-    static let feedSeedSuppressed = "feed_seed_suppressed"
-
     /// Returns the effective embedding dimension for the currently active provider.
     ///
     /// Nomic Embed Text v1.5 always produces 768-d vectors regardless of the

--- a/NewsCombApp/Services/ArticleIngestionService.swift
+++ b/NewsCombApp/Services/ArticleIngestionService.swift
@@ -188,6 +188,20 @@ struct ArticleIngestionService: Sendable {
                 throw IngestionError.feedItemNotFound(-1)
             }
 
+            // Requeue for hypergraph extraction. On a fresh ingest no
+            // article_hypergraph row exists yet so this UPDATE matches zero
+            // rows; on a re-ingest of an already-processed article the row's
+            // status flips to 'failed', which is what HypergraphService's
+            // unprocessed-articles query (`ah.id IS NULL OR ah.processing_status = 'failed'`)
+            // looks for. Without this, a re-ingest would silently leave the
+            // graph extracted from the old body.
+            if let rowId = row.id {
+                try db.execute(
+                    sql: "UPDATE article_hypergraph SET processing_status = 'failed' WHERE feed_item_id = ?",
+                    arguments: [rowId]
+                )
+            }
+
             logger.info("Ingested article #\(row.id ?? -1, privacy: .public) into feed #\(sourceId, privacy: .public)")
             return row
         }

--- a/NewsCombApp/Services/ArticleIngestionService.swift
+++ b/NewsCombApp/Services/ArticleIngestionService.swift
@@ -1,0 +1,258 @@
+import Foundation
+import GRDB
+import OSLog
+
+private let logger = Logger(subsystem: "com.newscomb", category: "ArticleIngestionService")
+
+/// Service for MCP-driven article ingestion: creating "manual" feed containers
+/// (no real RSS URL), inserting article content sourced from an MCP client, and
+/// re-fetching individual articles independently of the parent feed.
+struct ArticleIngestionService: Sendable {
+
+    /// URL scheme used for synthetic "manual" feed and article identifiers.
+    /// `RSSService.fetchFeed` short-circuits on sources whose `url` starts with
+    /// this scheme so the RSS parser never tries to network-fetch them.
+    static let manualURLScheme = "manual"
+
+    /// Minimum length the effective body must reach to be persisted. Mirrors
+    /// the threshold `RSSService.upsertFeedItem` enforces for RSS-sourced items.
+    static let minimumBodyLength = 100
+
+    /// Outcome of a per-article refresh, returned to the MCP client so it can
+    /// describe what changed without the caller having to re-query the row.
+    struct RefreshOutcome: Sendable {
+        let feedItemId: Int64
+        let previousLink: String
+        let newLink: String
+        let previousContentLength: Int
+        let newContentLength: Int
+
+        var linkChanged: Bool { previousLink != newLink }
+        var contentLengthDelta: Int { newContentLength - previousContentLength }
+    }
+
+    enum IngestionError: Error, LocalizedError, Sendable {
+        case sourceNotFound(Int64)
+        case sourceIsNotManual(Int64)
+        case emptyTitle
+        case bodyTooShort(actual: Int, minimum: Int)
+        case feedItemNotFound(Int64)
+        case missingLink(feedItemId: Int64)
+        case nonHTTPLink(scheme: String)
+        case extractionFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .sourceNotFound(let id):
+                return "Source #\(id) does not exist."
+            case .sourceIsNotManual(let id):
+                return "Source #\(id) is a real RSS feed; ingest_article only accepts manual feeds created via create_manual_feed."
+            case .emptyTitle:
+                return "Title must not be empty."
+            case .bodyTooShort(let actual, let minimum):
+                return "Body is \(actual) chars; minimum is \(minimum)."
+            case .feedItemNotFound(let id):
+                return "Feed item #\(id) does not exist."
+            case .missingLink(let id):
+                return "Feed item #\(id) has no link to refresh from."
+            case .nonHTTPLink(let scheme):
+                return "Cannot refresh: link scheme '\(scheme)' is not http(s)."
+            case .extractionFailed:
+                return "Content extraction returned no usable content."
+            }
+        }
+    }
+
+    /// Closure form of `ContentExtractService.extractContentWithFinalURL` so
+    /// tests can inject deterministic content without standing up a real HTTP server.
+    typealias Extractor = @Sendable (String) async -> ExtractionResult
+
+    private let dbQueue: DatabaseQueue
+    private let extract: Extractor
+
+    init(dbQueue: DatabaseQueue, extract: @escaping Extractor) {
+        self.dbQueue = dbQueue
+        self.extract = extract
+    }
+
+    /// Production initializer — binds to the active workspace's database and
+    /// the live Postlight-backed extractor.
+    init() {
+        let service = ContentExtractService()
+        self.init(
+            dbQueue: Database.current.dbQueue,
+            extract: { url in await service.extractContentWithFinalURL(from: url) }
+        )
+    }
+
+    /// Returns true when `url` identifies a manual feed (or manual article
+    /// placeholder) created by this service rather than a real RSS source.
+    static func isManualSourceURL(_ url: String) -> Bool {
+        url.hasPrefix("\(manualURLScheme):")
+    }
+
+    // MARK: - Manual feed creation
+
+    /// Inserts a new `rss_source` row whose URL is a synthetic `manual:<uuid>`,
+    /// so the standard RSS refresh path skips it but the UI continues to render it.
+    @discardableResult
+    func createManualFeed(title: String) throws -> RSSSource {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw IngestionError.emptyTitle
+        }
+
+        let syntheticURL = "\(Self.manualURLScheme):feed:\(UUID().uuidString)"
+        let now = Date()
+
+        let inserted = try dbQueue.write { db -> RSSSource in
+            let source = RSSSource(url: syntheticURL, title: trimmed, createdAt: now)
+            return try source.insertAndFetch(db)
+        }
+
+        logger.info("Created manual feed #\(inserted.id ?? -1, privacy: .public): \(trimmed, privacy: .public)")
+        return inserted
+    }
+
+    // MARK: - Article ingestion
+
+    /// Inserts (or upserts on `(source_id, guid)`) an article into a manual feed.
+    /// `link` is optional; when absent a synthetic `manual:item:<uuid>` is stored
+    /// so the `feed_item.link NOT NULL` constraint is honored.
+    @discardableResult
+    func ingestArticle(
+        sourceId: Int64,
+        title: String,
+        body: String,
+        link: String? = nil,
+        author: String? = nil,
+        pubDate: Date? = nil,
+        guid: String? = nil
+    ) throws -> FeedItem {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            throw IngestionError.emptyTitle
+        }
+
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedBody.count >= Self.minimumBodyLength else {
+            throw IngestionError.bodyTooShort(actual: trimmedBody.count, minimum: Self.minimumBodyLength)
+        }
+
+        let resolvedLink: String
+        if let link, !link.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            resolvedLink = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            resolvedLink = "\(Self.manualURLScheme):item:\(UUID().uuidString)"
+        }
+        let resolvedGuid = guid?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? resolvedLink
+
+        return try dbQueue.write { db -> FeedItem in
+            // Verify the source exists and is a manual feed.
+            guard let source = try RSSSource.filter(RSSSource.Columns.id == sourceId).fetchOne(db) else {
+                throw IngestionError.sourceNotFound(sourceId)
+            }
+            guard Self.isManualSourceURL(source.url) else {
+                throw IngestionError.sourceIsNotManual(sourceId)
+            }
+
+            try db.execute(
+                sql: """
+                    INSERT INTO feed_item (source_id, guid, title, link, pub_date, rss_description, full_content, author, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, NULL, ?, ?, unixepoch())
+                    ON CONFLICT(source_id, guid) DO UPDATE SET
+                        title = excluded.title,
+                        link = excluded.link,
+                        pub_date = excluded.pub_date,
+                        full_content = excluded.full_content,
+                        author = excluded.author,
+                        fetched_at = unixepoch()
+                """,
+                arguments: [
+                    sourceId,
+                    resolvedGuid,
+                    trimmedTitle,
+                    resolvedLink,
+                    pubDate?.timeIntervalSince1970,
+                    trimmedBody,
+                    author?.nonEmpty
+                ]
+            )
+
+            guard let row = try FeedItem
+                .filter(FeedItem.Columns.sourceId == sourceId)
+                .filter(FeedItem.Columns.guid == resolvedGuid)
+                .fetchOne(db)
+            else {
+                // Upsert produced no row — should be impossible. Treat as a logic error.
+                throw IngestionError.feedItemNotFound(-1)
+            }
+
+            logger.info("Ingested article #\(row.id ?? -1, privacy: .public) into feed #\(sourceId, privacy: .public)")
+            return row
+        }
+    }
+
+    // MARK: - Per-article refresh
+
+    /// Re-fetches `full_content` for a single article via the same Postlight
+    /// extraction pipeline RSS uses, independently of the parent feed's refresh.
+    @concurrent
+    func refreshArticle(feedItemId: Int64) async throws -> RefreshOutcome {
+        let item = try await dbQueue.read { db in
+            try FeedItem.filter(FeedItem.Columns.id == feedItemId).fetchOne(db)
+        }
+        guard let item, let id = item.id else {
+            throw IngestionError.feedItemNotFound(feedItemId)
+        }
+
+        let trimmedLink = item.link.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLink.isEmpty else {
+            throw IngestionError.missingLink(feedItemId: feedItemId)
+        }
+
+        let scheme = URL(string: trimmedLink)?.scheme?.lowercased() ?? ""
+        guard scheme == "http" || scheme == "https" else {
+            throw IngestionError.nonHTTPLink(scheme: scheme.isEmpty ? "(none)" : scheme)
+        }
+
+        let result = await extract(trimmedLink)
+        guard let content = result.content?.strippingHTMLTags(),
+              content.trimmingCharacters(in: .whitespacesAndNewlines).count >= Self.minimumBodyLength
+        else {
+            throw IngestionError.extractionFailed
+        }
+
+        let newLink = result.finalURL ?? trimmedLink
+        let previousLength = item.fullContent?.count ?? 0
+
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE feed_item
+                    SET full_content = ?, link = ?, fetched_at = unixepoch()
+                    WHERE id = ?
+                """,
+                arguments: [content, newLink, id]
+            )
+        }
+
+        logger.info("Refreshed article #\(id, privacy: .public) (\(previousLength, privacy: .public) → \(content.count, privacy: .public) chars)")
+        return RefreshOutcome(
+            feedItemId: id,
+            previousLink: trimmedLink,
+            newLink: newLink,
+            previousContentLength: previousLength,
+            newContentLength: content.count
+        )
+    }
+}
+
+private extension String {
+    /// Returns nil when the string is empty after trimming, otherwise the trimmed string.
+    /// Used to coerce empty MCP-tool inputs to SQL NULL.
+    var nonEmpty: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/NewsCombApp/Services/DatabaseService.swift
+++ b/NewsCombApp/Services/DatabaseService.swift
@@ -629,9 +629,6 @@ public final class Database: Sendable {
 
             // Create or recreate vec0 virtual tables with the configured embedding dimension
             try createVec0Tables(db)
-
-            // Seed default RSS sources if none exist
-            try seedDefaultRSSSources(db)
         }
     }
 
@@ -774,28 +771,25 @@ public final class Database: Sendable {
         Self.logger.info("Default settings seeded successfully")
     }
 
-    /// Seeds default RSS sources into the database.
-    /// Only seeds if no sources exist yet (first app launch) AND the
-    /// `feed_seed_suppressed` flag isn't set (workspace explicitly provisioned
-    /// empty).
-    private func seedDefaultRSSSources(_ db: GRDB.Database) throws {
-        // Honor explicit opt-out — set by `WorkspaceCoordinator.provisionNewWorkspace`.
-        let isSuppressed = try AppSettings
-            .filter(AppSettings.Columns.key == AppSettings.feedSeedSuppressed)
-            .fetchOne(db) != nil
-        if isSuppressed {
-            Self.logger.info("RSS feed seeding suppressed for this workspace")
-            return
+    /// Inserts the curated default tech-news RSS feeds into this workspace.
+    /// User-invoked from Settings → Feed Settings → "Seed Default Tech Feeds".
+    /// Never runs implicitly during migration: new workspaces start empty so
+    /// the user can choose feeds appropriate to their domain.
+    ///
+    /// Uses `INSERT OR IGNORE` keyed on `url`, so calling repeatedly is
+    /// idempotent — only feeds whose URLs aren't already present get inserted.
+    /// Returns the number of feeds actually inserted.
+    @discardableResult
+    public func seedDefaultRSSFeeds() throws -> Int {
+        try dbQueue.write { db in
+            try Self.insertDefaultRSSFeeds(db)
         }
+    }
 
-        // Check if any sources already exist
-        let sourceCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
-        guard sourceCount == 0 else {
-            Self.logger.info("RSS sources already exist, skipping seed")
-            return
-        }
-
-        // Default curated feed sources
+    /// Implementation of the default-feed insert. Static so callers running
+    /// inside an existing write transaction can reuse it without nesting.
+    @discardableResult
+    static func insertDefaultRSSFeeds(_ db: GRDB.Database) throws -> Int {
         let defaultSources: [(url: String, title: String)] = [
             // Cloud Providers
             ("https://aws.amazon.com/blogs/aws/feed", "AWS Blog"),
@@ -821,14 +815,16 @@ public final class Database: Sendable {
             ("https://mshibanami.github.io/GitHubTrendingRSS/weekly/all.xml", "GitHub Trending"),
         ]
 
+        var inserted = 0
         for source in defaultSources {
             try db.execute(
                 sql: "INSERT OR IGNORE INTO rss_source (url, title) VALUES (?, ?)",
                 arguments: [source.url, source.title]
             )
+            inserted += db.changesCount
         }
-
-        Self.logger.info("Default RSS sources seeded: \(defaultSources.count) sources")
+        Self.logger.info("Default RSS feeds: inserted \(inserted) of \(defaultSources.count) (rest already present)")
+        return inserted
     }
 
     func read<T>(_ block: (GRDB.Database) throws -> T) throws -> T {

--- a/NewsCombApp/Services/RSSService.swift
+++ b/NewsCombApp/Services/RSSService.swift
@@ -88,6 +88,16 @@ struct RSSService {
             )
         }
 
+        // Manual feeds carry MCP-ingested articles only; there is no remote RSS to fetch.
+        if ArticleIngestionService.isManualSourceURL(source.url) {
+            return FetchResult(
+                sourceId: sourceId,
+                sourceName: source.title ?? source.url,
+                itemCount: 0,
+                error: nil
+            )
+        }
+
         guard let url = URL(string: source.url) else {
             return FetchResult(
                 sourceId: sourceId,

--- a/NewsCombApp/Services/WorkspaceCoordinator.swift
+++ b/NewsCombApp/Services/WorkspaceCoordinator.swift
@@ -305,16 +305,14 @@ final class WorkspaceCoordinator {
     }
 
     /// Provisions a new workspace from the currently-active one for the
-    /// **File → New Workspace…** flow:
+    /// **File → New Workspace…** flow.
     ///
-    /// 1. Copies portable app settings from the active workspace (LLM keys,
-    ///    model selections, prompts, algorithm parameters).
-    /// 2. Sets `feed_seed_suppressed = "1"` in the new workspace so future
-    ///    migrations don't re-seed the curated default RSS feeds.
-    /// 3. Deletes the seeded RSS feeds the migration just inserted.
-    ///
-    /// The user picks feeds appropriate to the new workspace's domain rather
-    /// than inheriting the source workspace's feeds OR the seed defaults.
+    /// Copies portable app settings from the active workspace (LLM keys,
+    /// model selections, prompts, algorithm parameters) into the target.
+    /// The new workspace starts with an empty `rss_source` table — the user
+    /// picks feeds appropriate to the new domain via Settings → Feed Settings,
+    /// where a "Seed Default Tech Feeds" button is also available as a
+    /// shortcut.
     ///
     /// Returns `true` if provisioning happened, `false` if there was no
     /// active workspace or `target` already equals the active workspace.
@@ -324,29 +322,10 @@ final class WorkspaceCoordinator {
         let canonicalTarget = target.canonicalDirectoryURL
         guard active.directory != canonicalTarget else { return false }
 
-        // Step 1: copy portable settings (this also runs migrate on target,
-        // which seeds defaults including the curated RSS feed list).
         try copyAppSettings(from: active.directory, to: canonicalTarget)
 
-        // Steps 2 & 3: in a single write, suppress future seeding and clear
-        // the seeded rows. Doing both in one transaction guarantees a consistent
-        // post-state — either the workspace is "provisioned empty" or unchanged.
-        let targetDB = try Database(directory: canonicalTarget)
-        let removed = try targetDB.dbQueue.write { db -> Int in
-            try db.execute(
-                sql: """
-                    INSERT INTO app_settings (key, value) VALUES (?, ?)
-                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                """,
-                arguments: [AppSettings.feedSeedSuppressed, "1"]
-            )
-            let before = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
-            try db.execute(sql: "DELETE FROM rss_source")
-            return before
-        }
-
         logger.notice(
-            "Provisioned new workspace at \(canonicalTarget.path(percentEncoded: false), privacy: .public): copied settings, suppressed feed seeding, removed \(removed, privacy: .public) seeded feeds"
+            "Provisioned new workspace at \(canonicalTarget.path(percentEncoded: false), privacy: .public): copied settings, no feeds seeded"
         )
         return true
     }

--- a/NewsCombApp/ViewModels/SettingsViewModel.swift
+++ b/NewsCombApp/ViewModels/SettingsViewModel.swift
@@ -75,6 +75,8 @@ class SettingsViewModel {
     var newSourceURL: String = ""
     var openRouterKey: String = ""
     var errorMessage: String?
+    /// Set after a successful default-feeds seed; the view shows it as an info alert.
+    var seedFeedsResultMessage: String?
 
     // LLM Configuration
     var llmProvider: LLMProviderOption = .none
@@ -631,6 +633,20 @@ class SettingsViewModel {
 
     func saveArticleAgeLimitDays() {
         saveAPIKey(key: AppSettings.articleAgeLimitDays, value: String(articleAgeLimitDays))
+    }
+
+    /// Inserts the curated default tech-news RSS feeds into the active workspace.
+    /// Idempotent — feeds whose URLs already exist are skipped.
+    func seedDefaultFeeds() {
+        do {
+            let inserted = try Database.current.seedDefaultRSSFeeds()
+            loadRSSSources()
+            seedFeedsResultMessage = inserted == 0
+                ? "All default feeds were already present. No new feeds added."
+                : "Added \(inserted) default tech feed\(inserted == 1 ? "" : "s")."
+        } catch {
+            errorMessage = "Failed to seed default feeds: \(error.localizedDescription)"
+        }
     }
 
     // MARK: - Algorithm Parameters Save Methods

--- a/NewsCombApp/Views/SettingsView.swift
+++ b/NewsCombApp/Views/SettingsView.swift
@@ -53,10 +53,28 @@ struct SettingsView: View {
             .onChange(of: viewModel.articleAgeLimitDays) {
                 viewModel.saveArticleAgeLimitDays()
             }
+
+            HStack {
+                Text("Seed Default Tech Feeds")
+                Spacer()
+                Button("Add Default Feeds", systemImage: "plus.rectangle.on.folder") {
+                    viewModel.seedDefaultFeeds()
+                }
+            }
         } header: {
             Text("Feed Settings")
         } footer: {
-            Text("Only fetch articles published within the last \(viewModel.articleAgeLimitDays) day\(viewModel.articleAgeLimitDays == 1 ? "" : "s"). Older articles will be skipped.")
+            Text("Only fetch articles published within the last \(viewModel.articleAgeLimitDays) day\(viewModel.articleAgeLimitDays == 1 ? "" : "s"). Older articles will be skipped. Use \"Add Default Feeds\" to insert a curated set of cloud, AI, and tech-news feeds — already-present URLs are skipped.")
+        }
+        .alert("Default Feeds", isPresented: .init(
+            get: { viewModel.seedFeedsResultMessage != nil },
+            set: { if !$0 { viewModel.seedFeedsResultMessage = nil } }
+        )) {
+            Button("OK") { viewModel.seedFeedsResultMessage = nil }
+        } message: {
+            if let message = viewModel.seedFeedsResultMessage {
+                Text(message)
+            }
         }
     }
 

--- a/NewsCombApp/Views/WorkspaceCommands.swift
+++ b/NewsCombApp/Views/WorkspaceCommands.swift
@@ -61,7 +61,7 @@ struct WorkspaceCommands: Commands {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.message = "Choose a folder for the new NewsComb workspace. The folder may be empty or contain an existing newscomb.sqlite."
+        panel.message = "Choose an empty folder for the new NewsComb workspace. To open an existing workspace, use Open Workspace… instead."
         panel.prompt = "Use Folder"
         if panel.runModal() == .OK, let url = panel.url {
             attemptSwitch(to: url, copyIfNew: true)
@@ -84,13 +84,25 @@ struct WorkspaceCommands: Commands {
     /// Routes a workspace switch through `WorkspaceCoordinator.switchWorkspace`,
     /// optionally provisioning the target as a brand-new workspace first
     /// (used for File → New Workspace…). Provisioning copies the current
-    /// workspace's portable settings, suppresses default-feed seeding, and
-    /// clears any seeded feeds. Failure during provisioning aborts the
-    /// switch — better to surface the error than relaunch into an
-    /// inconsistent workspace.
+    /// workspace's portable settings into the new database. Failure during
+    /// provisioning aborts the switch — better to surface the error than
+    /// relaunch into an inconsistent workspace.
+    ///
+    /// When `copyIfNew` is true, the target folder must not already contain a
+    /// `newscomb.sqlite`. We refuse rather than silently fall back to "open
+    /// existing" — the user explicitly chose New Workspace, and the silent
+    /// fallback was the cause of past reports of missing LLM keys in newly-
+    /// created workspaces.
     private func attemptSwitch(to url: URL, copyIfNew: Bool) {
         do {
-            if copyIfNew && Self.isNewWorkspace(at: url) {
+            if copyIfNew {
+                guard Self.isNewWorkspace(at: url) else {
+                    showError(
+                        title: "Folder already contains a workspace",
+                        message: "\(url.path(percentEncoded: false)) already has a newscomb.sqlite file. To start fresh, choose an empty folder. To open this workspace, use File → Open Workspace… instead."
+                    )
+                    return
+                }
                 _ = try coordinator.provisionNewWorkspace(at: url)
             }
             _ = try coordinator.switchWorkspace(to: url)

--- a/NewsCombAppTests/ArticleIngestionServiceTests.swift
+++ b/NewsCombAppTests/ArticleIngestionServiceTests.swift
@@ -1,0 +1,369 @@
+import XCTest
+import GRDB
+@testable import NewsCombApp
+
+/// Tests for `ArticleIngestionService` — the MCP-driven manual feed and
+/// article ingestion path. Uses an in-memory `DatabaseQueue` and a stub
+/// extractor so no network is required.
+final class ArticleIngestionServiceTests: XCTestCase {
+
+    private var dbQueue: DatabaseQueue!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+        dbQueue = try DatabaseQueue(configuration: config)
+        try dbQueue.write { db in
+            try Self.createSchema(db)
+        }
+    }
+
+    override func tearDown() {
+        dbQueue = nil
+        super.tearDown()
+    }
+
+    // MARK: - createManualFeed
+
+    func testCreateManualFeedInsertsRowWithSyntheticURL() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "  My Notes  ")
+
+        XCTAssertNotNil(source.id)
+        XCTAssertEqual(source.title, "My Notes", "Title should be trimmed")
+        XCTAssertTrue(source.url.hasPrefix("manual:feed:"), "URL should use synthetic manual scheme, got '\(source.url)'")
+
+        try dbQueue.read { db in
+            let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")!
+            XCTAssertEqual(count, 1)
+        }
+    }
+
+    func testCreateManualFeedRejectsEmptyTitle() {
+        let service = makeService()
+        XCTAssertThrowsError(try service.createManualFeed(title: "   ")) { error in
+            guard case ArticleIngestionService.IngestionError.emptyTitle = error else {
+                return XCTFail("Expected .emptyTitle, got \(error)")
+            }
+        }
+    }
+
+    func testCreateManualFeedGeneratesUniqueURLs() throws {
+        let service = makeService()
+        let first = try service.createManualFeed(title: "Feed A")
+        let second = try service.createManualFeed(title: "Feed B")
+        XCTAssertNotEqual(first.url, second.url, "Each manual feed must get a fresh synthetic URL")
+    }
+
+    func testIsManualSourceURLDetectsScheme() {
+        XCTAssertTrue(ArticleIngestionService.isManualSourceURL("manual:feed:abc"))
+        XCTAssertTrue(ArticleIngestionService.isManualSourceURL("manual:item:abc"))
+        XCTAssertFalse(ArticleIngestionService.isManualSourceURL("https://example.com/feed.xml"))
+        XCTAssertFalse(ArticleIngestionService.isManualSourceURL(""))
+    }
+
+    // MARK: - ingestArticle
+
+    func testIngestArticleStoresFullContent() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+
+        let body = String(repeating: "Lorem ipsum dolor sit amet. ", count: 8)  // > 100 chars
+        let article = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "Hello",
+            body: body,
+            link: "https://example.com/post",
+            author: "Alice",
+            pubDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        XCTAssertNotNil(article.id)
+        XCTAssertEqual(article.title, "Hello")
+        XCTAssertEqual(article.link, "https://example.com/post")
+        XCTAssertEqual(article.author, "Alice")
+        XCTAssertEqual(article.fullContent, body.trimmingCharacters(in: .whitespacesAndNewlines))
+        XCTAssertEqual(article.guid, "https://example.com/post", "guid should default to link")
+        XCTAssertEqual(article.pubDate?.timeIntervalSince1970 ?? 0, 1_700_000_000, accuracy: 0.001)
+    }
+
+    func testIngestArticleGeneratesSyntheticLinkWhenAbsent() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+
+        let body = String(repeating: "abcdefghij", count: 12)  // 120 chars
+        let article = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: body
+        )
+
+        XCTAssertTrue(article.link.hasPrefix("manual:item:"), "Synthetic link should be generated, got '\(article.link)'")
+        XCTAssertEqual(article.guid, article.link, "guid should equal the synthetic link")
+    }
+
+    func testIngestArticleUpsertsOnConflictingGuid() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+        let body1 = String(repeating: "first body content. ", count: 10)  // ~200 chars
+        let body2 = String(repeating: "second body content. ", count: 10)
+
+        let first = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "v1",
+            body: body1,
+            link: "https://example.com/x",
+            guid: "stable-guid"
+        )
+        let second = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "v2",
+            body: body2,
+            link: "https://example.com/x-renamed",
+            guid: "stable-guid"
+        )
+
+        XCTAssertEqual(first.id, second.id, "Same guid should update the same row")
+        XCTAssertEqual(second.title, "v2")
+        XCTAssertEqual(second.link, "https://example.com/x-renamed")
+        XCTAssertEqual(second.fullContent, body2.trimmingCharacters(in: .whitespacesAndNewlines))
+
+        try dbQueue.read { db in
+            let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feed_item")!
+            XCTAssertEqual(count, 1, "Upsert must not create a duplicate row")
+        }
+    }
+
+    func testIngestArticleRejectsTooShortBody() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+
+        XCTAssertThrowsError(try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: "too short"
+        )) { error in
+            guard case ArticleIngestionService.IngestionError.bodyTooShort = error else {
+                return XCTFail("Expected .bodyTooShort, got \(error)")
+            }
+        }
+    }
+
+    func testIngestArticleRejectsEmptyTitle() throws {
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+        let body = String(repeating: "x", count: 200)
+
+        XCTAssertThrowsError(try service.ingestArticle(
+            sourceId: source.id!,
+            title: "   ",
+            body: body
+        )) { error in
+            guard case ArticleIngestionService.IngestionError.emptyTitle = error else {
+                return XCTFail("Expected .emptyTitle, got \(error)")
+            }
+        }
+    }
+
+    func testIngestArticleRejectsUnknownSource() {
+        let service = makeService()
+        let body = String(repeating: "x", count: 200)
+
+        XCTAssertThrowsError(try service.ingestArticle(
+            sourceId: 99_999,
+            title: "T",
+            body: body
+        )) { error in
+            guard case ArticleIngestionService.IngestionError.sourceNotFound = error else {
+                return XCTFail("Expected .sourceNotFound, got \(error)")
+            }
+        }
+    }
+
+    func testIngestArticleRejectsNonManualSource() throws {
+        // Insert a real RSS source by hand
+        let realId = try dbQueue.write { db -> Int64 in
+            try db.execute(sql: "INSERT INTO rss_source (url, title) VALUES (?, ?)",
+                           arguments: ["https://example.com/feed.xml", "Real Feed"])
+            return db.lastInsertedRowID
+        }
+
+        let service = makeService()
+        let body = String(repeating: "x", count: 200)
+
+        XCTAssertThrowsError(try service.ingestArticle(
+            sourceId: realId,
+            title: "T",
+            body: body
+        )) { error in
+            guard case ArticleIngestionService.IngestionError.sourceIsNotManual = error else {
+                return XCTFail("Expected .sourceIsNotManual, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - refreshArticle
+
+    func testRefreshArticleUpdatesContentAndLinkOnRedirect() async throws {
+        let stubbed = ExtractionResult(
+            content: String(repeating: "fresh content. ", count: 20),  // ~300 chars
+            finalURL: "https://example.com/redirected"
+        )
+        let service = makeService(extract: { _ in stubbed })
+
+        let source = try service.createManualFeed(title: "Notes")
+        let originalBody = String(repeating: "old content. ", count: 10)
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: originalBody,
+            link: "https://example.com/original"
+        )
+
+        let outcome = try await service.refreshArticle(feedItemId: item.id!)
+
+        XCTAssertEqual(outcome.feedItemId, item.id!)
+        XCTAssertEqual(outcome.previousLink, "https://example.com/original")
+        XCTAssertEqual(outcome.newLink, "https://example.com/redirected")
+        XCTAssertTrue(outcome.linkChanged)
+        XCTAssertEqual(outcome.previousContentLength, originalBody.trimmingCharacters(in: .whitespacesAndNewlines).count)
+        XCTAssertGreaterThan(outcome.newContentLength, 0)
+
+        try await dbQueue.read { db in
+            let row = try FeedItem.filter(FeedItem.Columns.id == item.id!).fetchOne(db)
+            XCTAssertEqual(row?.link, "https://example.com/redirected")
+            // The service runs strippingHTMLTags() over extracted content, which
+            // also trims surrounding whitespace and collapses runs.
+            XCTAssertEqual(row?.fullContent, stubbed.content?.strippingHTMLTags())
+        }
+    }
+
+    func testRefreshArticleWithoutRedirectKeepsLink() async throws {
+        let stubbed = ExtractionResult(
+            content: String(repeating: "abc", count: 50),
+            finalURL: nil
+        )
+        let service = makeService(extract: { _ in stubbed })
+        let source = try service.createManualFeed(title: "Notes")
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: String(repeating: "x", count: 200),
+            link: "https://example.com/keep"
+        )
+
+        let outcome = try await service.refreshArticle(feedItemId: item.id!)
+        XCTAssertEqual(outcome.newLink, "https://example.com/keep")
+        XCTAssertFalse(outcome.linkChanged)
+    }
+
+    func testRefreshArticleThrowsOnUnknownId() async {
+        let service = makeService(extract: { _ in ExtractionResult(content: "ignored", finalURL: nil) })
+        do {
+            _ = try await service.refreshArticle(feedItemId: 12_345)
+            XCTFail("Expected .feedItemNotFound to be thrown")
+        } catch ArticleIngestionService.IngestionError.feedItemNotFound {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRefreshArticleRejectsManualLinkScheme() async throws {
+        let service = makeService(extract: { _ in
+            // The extractor must not be invoked; if it is, return content that would otherwise succeed.
+            ExtractionResult(content: String(repeating: "x", count: 200), finalURL: nil)
+        })
+        let source = try service.createManualFeed(title: "Notes")
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: String(repeating: "x", count: 200)
+            // No link → synthetic manual:item:<uuid>
+        )
+
+        do {
+            _ = try await service.refreshArticle(feedItemId: item.id!)
+            XCTFail("Expected .nonHTTPLink for synthetic manual link")
+        } catch ArticleIngestionService.IngestionError.nonHTTPLink {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRefreshArticleThrowsWhenExtractionReturnsNil() async throws {
+        let service = makeService(extract: { _ in ExtractionResult(content: nil, finalURL: nil) })
+        let source = try service.createManualFeed(title: "Notes")
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: String(repeating: "x", count: 200),
+            link: "https://example.com/x"
+        )
+
+        do {
+            _ = try await service.refreshArticle(feedItemId: item.id!)
+            XCTFail("Expected .extractionFailed")
+        } catch ArticleIngestionService.IngestionError.extractionFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRefreshArticleThrowsWhenExtractedContentTooShort() async throws {
+        let service = makeService(extract: { _ in ExtractionResult(content: "tiny", finalURL: nil) })
+        let source = try service.createManualFeed(title: "Notes")
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "T",
+            body: String(repeating: "x", count: 200),
+            link: "https://example.com/x"
+        )
+
+        do {
+            _ = try await service.refreshArticle(feedItemId: item.id!)
+            XCTFail("Expected .extractionFailed for sub-minimum extracted content")
+        } catch ArticleIngestionService.IngestionError.extractionFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeService(
+        extract: @escaping ArticleIngestionService.Extractor = { _ in
+            ExtractionResult(content: nil, finalURL: nil)
+        }
+    ) -> ArticleIngestionService {
+        ArticleIngestionService(dbQueue: dbQueue, extract: extract)
+    }
+
+    private static func createSchema(_ db: GRDB.Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE rss_source (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT NOT NULL UNIQUE,
+                title TEXT,
+                created_at REAL NOT NULL DEFAULT (unixepoch())
+            );
+            CREATE TABLE feed_item (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL REFERENCES rss_source(id) ON DELETE CASCADE,
+                guid TEXT NOT NULL,
+                title TEXT NOT NULL,
+                link TEXT NOT NULL,
+                pub_date REAL,
+                rss_description TEXT,
+                full_content TEXT,
+                author TEXT,
+                fetched_at REAL NOT NULL DEFAULT (unixepoch()),
+                UNIQUE(source_id, guid)
+            );
+        """)
+    }
+}

--- a/NewsCombAppTests/ArticleIngestionServiceTests.swift
+++ b/NewsCombAppTests/ArticleIngestionServiceTests.swift
@@ -135,6 +135,86 @@ final class ArticleIngestionServiceTests: XCTestCase {
         }
     }
 
+    func testIngestArticleDoesNotCreateProcessingStatusOnFreshIngest() throws {
+        // Fresh ingest must not insert an article_hypergraph row; the
+        // requeue UPDATE should match zero rows. The next batch
+        // process_knowledge_graph run will pick this article up via the
+        // `ah.id IS NULL` branch of the unprocessed-articles query.
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+        let body = String(repeating: "fresh body content. ", count: 10)
+
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "Hello",
+            body: body,
+            guid: "stable-guid"
+        )
+
+        try dbQueue.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM article_hypergraph WHERE feed_item_id = ?",
+                arguments: [item.id!]
+            )!
+            XCTAssertEqual(count, 0, "Fresh ingest must not create an article_hypergraph row")
+        }
+    }
+
+    func testIngestArticleRequeuesAlreadyProcessedArticleOnUpsert() throws {
+        // Re-ingesting an article that has already been processed by the
+        // hypergraph pipeline must flip its processing_status to 'failed'
+        // so the next process_knowledge_graph run re-extracts from the
+        // (now updated) body. Without this, the article's chunks and
+        // graph entities would silently remain attached to the old body.
+        let service = makeService()
+        let source = try service.createManualFeed(title: "Notes")
+        let body1 = String(repeating: "original body. ", count: 12)
+
+        let item = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "v1",
+            body: body1,
+            guid: "stable-guid"
+        )
+
+        // Simulate the article having been processed by HypergraphService.
+        try dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO article_hypergraph (feed_item_id, processing_status, chunk_count)
+                    VALUES (?, 'completed', 4)
+                """,
+                arguments: [item.id!]
+            )
+        }
+
+        // Re-ingest with new body, same guid.
+        let body2 = String(repeating: "revised body. ", count: 12)
+        _ = try service.ingestArticle(
+            sourceId: source.id!,
+            title: "v2",
+            body: body2,
+            guid: "stable-guid"
+        )
+
+        try dbQueue.read { db in
+            let status = try String.fetchOne(
+                db,
+                sql: "SELECT processing_status FROM article_hypergraph WHERE feed_item_id = ?",
+                arguments: [item.id!]
+            )
+            XCTAssertEqual(status, "failed", "Re-ingest must requeue the article for reprocessing")
+
+            let rowCount = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM article_hypergraph WHERE feed_item_id = ?",
+                arguments: [item.id!]
+            )!
+            XCTAssertEqual(rowCount, 1, "Requeue must update in place, not insert a duplicate row")
+        }
+    }
+
     func testIngestArticleRejectsTooShortBody() throws {
         let service = makeService()
         let source = try service.createManualFeed(title: "Notes")
@@ -363,6 +443,15 @@ final class ArticleIngestionServiceTests: XCTestCase {
                 author TEXT,
                 fetched_at REAL NOT NULL DEFAULT (unixepoch()),
                 UNIQUE(source_id, guid)
+            );
+            CREATE TABLE article_hypergraph (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                feed_item_id INTEGER NOT NULL REFERENCES feed_item(id) ON DELETE CASCADE,
+                processed_at REAL NOT NULL DEFAULT (unixepoch()),
+                processing_status TEXT NOT NULL DEFAULT 'pending',
+                error_message TEXT,
+                chunk_count INTEGER DEFAULT 0,
+                UNIQUE(feed_item_id)
             );
         """)
     }

--- a/NewsCombAppTests/DatabaseWorkspaceInitTests.swift
+++ b/NewsCombAppTests/DatabaseWorkspaceInitTests.swift
@@ -97,4 +97,67 @@ final class DatabaseWorkspaceInitTests: XCTestCase {
         Database.setCurrent(db)
         XCTAssertEqual(Database.current.workspaceDirectory, dir.canonicalDirectoryURL)
     }
+
+    // MARK: - Default RSS feed seeding (explicit, opt-in)
+
+    func testFirstOpenLeavesFeedsEmpty() throws {
+        let dir = tempRoot.appending(path: "FirstOpen")
+        let db = try Database(directory: dir)
+        let count = try db.dbQueue.read {
+            try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+        }
+        XCTAssertEqual(count, 0, "Brand-new workspaces must NOT auto-seed feeds")
+    }
+
+    func testSeedDefaultRSSFeedsInsertsFullDefaultSet() throws {
+        let dir = tempRoot.appending(path: "ExplicitSeed")
+        let db = try Database(directory: dir)
+
+        let inserted = try db.seedDefaultRSSFeeds()
+        XCTAssertGreaterThan(inserted, 0, "First seed should insert at least one feed")
+
+        let count = try db.dbQueue.read {
+            try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+        }
+        XCTAssertEqual(count, inserted, "Total feeds should equal what was just inserted")
+    }
+
+    func testSeedDefaultRSSFeedsIsIdempotent() throws {
+        let dir = tempRoot.appending(path: "Idempotent")
+        let db = try Database(directory: dir)
+
+        let firstRun = try db.seedDefaultRSSFeeds()
+        let secondRun = try db.seedDefaultRSSFeeds()
+        XCTAssertGreaterThan(firstRun, 0)
+        XCTAssertEqual(secondRun, 0, "Re-seeding should insert nothing — defaults already present")
+
+        let count = try db.dbQueue.read {
+            try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+        }
+        XCTAssertEqual(count, firstRun, "Total count must not double after a second seed call")
+    }
+
+    /// Regression: deleting all feeds and re-opening must NOT re-seed (since
+    /// auto-seeding is gone, this is now trivially true — but we keep the
+    /// test as a guard against any future re-introduction of auto-seeding).
+    func testDeletedFeedsDoNotReturnAfterReopen() throws {
+        let dir = tempRoot.appending(path: "DeleteAndReopen")
+
+        let initial = try Database(directory: dir)
+        try initial.seedDefaultRSSFeeds()
+        let initialCount = try initial.dbQueue.read {
+            try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+        }
+        XCTAssertGreaterThan(initialCount, 0)
+
+        try initial.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM rss_source")
+        }
+
+        let reopened = try Database(directory: dir)
+        let reopenedCount = try reopened.dbQueue.read {
+            try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM rss_source") ?? 0
+        }
+        XCTAssertEqual(reopenedCount, 0, "Deleted feeds must stay deleted across reopens")
+    }
 }

--- a/NewsCombAppTests/MCPArticleIngestionToolTests.swift
+++ b/NewsCombAppTests/MCPArticleIngestionToolTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import MCP
+@testable import NewsCombApp
+
+/// Argument-validation tests for the new MCP tools — `create_manual_feed`,
+/// `ingest_article`, and `refresh_article`. These exercise only the parameter
+/// decoding layer (which throws before reaching `MCPAppCoordinator.shared`),
+/// so they don't require a live database. End-to-end coverage of the actual
+/// ingestion logic lives in `ArticleIngestionServiceTests`.
+final class MCPArticleIngestionToolTests: XCTestCase {
+
+    // MARK: - create_manual_feed
+
+    func testCreateManualFeedRejectsMissingTitle() async {
+        await expectMCPError(messageContains: "title") {
+            try await MCPCreateManualFeedTool.run(arguments: [:])
+        }
+    }
+
+    func testCreateManualFeedRejectsEmptyTitle() async {
+        await expectMCPError(messageContains: "title") {
+            try await MCPCreateManualFeedTool.run(arguments: ["title": .string("")])
+        }
+    }
+
+    // MARK: - ingest_article
+
+    func testIngestArticleRejectsMissingSourceId() async {
+        let args: [String: Value] = [
+            "title": .string("T"),
+            "body": .string(String(repeating: "x", count: 200))
+        ]
+        await expectMCPError(messageContains: "source_id") {
+            try await MCPIngestArticleTool.run(arguments: args)
+        }
+    }
+
+    func testIngestArticleRejectsMissingTitle() async {
+        let args: [String: Value] = [
+            "source_id": .int(1),
+            "body": .string(String(repeating: "x", count: 200))
+        ]
+        await expectMCPError(messageContains: "title") {
+            try await MCPIngestArticleTool.run(arguments: args)
+        }
+    }
+
+    func testIngestArticleRejectsMissingBody() async {
+        let args: [String: Value] = [
+            "source_id": .int(1),
+            "title": .string("T")
+        ]
+        await expectMCPError(messageContains: "body") {
+            try await MCPIngestArticleTool.run(arguments: args)
+        }
+    }
+
+    func testIngestArticleRejectsMalformedPubDate() async {
+        let args: [String: Value] = [
+            "source_id": .int(1),
+            "title": .string("T"),
+            "body": .string(String(repeating: "x", count: 200)),
+            "pub_date": .string("not-a-date")
+        ]
+        await expectMCPError(messageContains: "pub_date") {
+            try await MCPIngestArticleTool.run(arguments: args)
+        }
+    }
+
+    // MARK: - refresh_article
+
+    func testRefreshArticleRejectsMissingFeedItemId() async {
+        await expectMCPError(messageContains: "feed_item_id") {
+            try await MCPRefreshArticleTool.run(arguments: [:])
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Asserts that the closure throws an `MCPToolError` whose message
+    /// contains `messageContains`.
+    private func expectMCPError<T>(
+        messageContains: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ block: () async throws -> T
+    ) async {
+        do {
+            _ = try await block()
+            XCTFail("Expected MCPToolError, got success", file: file, line: line)
+        } catch let error as MCPToolError {
+            XCTAssertTrue(
+                error.message.localizedStandardContains(messageContains),
+                "Error message '\(error.message)' should contain '\(messageContains)'",
+                file: file, line: line
+            )
+        } catch {
+            XCTFail("Expected MCPToolError, got \(type(of: error)): \(error)", file: file, line: line)
+        }
+    }
+}

--- a/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
+++ b/NewsCombAppTests/WorkspaceCoordinatorCopySettingsTests.swift
@@ -183,34 +183,20 @@ final class WorkspaceCoordinatorCopySettingsTests: XCTestCase {
         XCTAssertEqual(count, 0, "Provisioned workspace should have no RSS feeds")
     }
 
-    func testProvisionedWorkspaceDoesNotReseedFeedsAfterReopen() throws {
+    func testProvisionedWorkspaceDoesNotAcquireFeedsAfterReopen() throws {
         let sourceDir = tempRoot.appending(path: "Source")
         let targetDir = tempRoot.appending(path: "Target")
         try sut.openWorkspace(at: sourceDir)
         try sut.provisionNewWorkspace(at: targetDir)
 
-        // First reopen — runs migrate again (which would re-seed if the flag
-        // weren't honored).
-        do {
+        // Two consecutive reopens — migrate runs each time, but auto-seeding
+        // is gone so feeds remain empty regardless.
+        for _ in 0..<2 {
             let reopened = try Database(directory: targetDir)
             let count = try reopened.dbQueue.read { db in
                 try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")
             }
-            XCTAssertEqual(count, 0, "Reopen #1: feeds must stay empty")
-            XCTAssertEqual(
-                try readSetting(AppSettings.feedSeedSuppressed, in: reopened),
-                "1",
-                "Suppression flag should still be set after reopen"
-            )
-        }
-
-        // Second reopen — defensive: the flag still survives multiple opens.
-        do {
-            let reopened = try Database(directory: targetDir)
-            let count = try reopened.dbQueue.read { db in
-                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")
-            }
-            XCTAssertEqual(count, 0, "Reopen #2: feeds must stay empty")
+            XCTAssertEqual(count, 0, "Reopens must not introduce feeds")
         }
     }
 


### PR DESCRIPTION
## Summary

Adds manual-feed article ingestion via MCP, plus three follow-on improvements that landed during the same effort.

## Commits

- **bc0d5f635** — *MCP: ingest articles via manual feeds and refresh single articles*. Three new MCP tools: `create_manual_feed`, `ingest_article`, `refresh_article`. Manual feeds use a synthetic `manual:` URL scheme that the regular RSS refresh path skips. `ingest_article` upserts on `(source_id, guid)` with a 100-char minimum body length. `refresh_article` re-fetches `full_content` for one article via Postlight, rejecting `manual:` scheme links. 17 unit tests in `ArticleIngestionServiceTests` and `MCPArticleIngestionToolTests`.
- **75d732b54** — *Workspaces: opt-in feed seeding, fail loudly on non-empty New Workspace target*. `Database` no longer auto-seeds RSS feeds on first run; the `feed_seed_completed` flag is removed. New Workspace flow refuses to overwrite a non-empty target directory with a clear error rather than silently merging.
- **607a741c5** — *MCP: requeue article for re-extraction on ingest_article upsert*. Re-ingesting an existing article via `ingest_article` previously upserted `feed_item.full_content` but did not flip `article_hypergraph.processing_status`, so the next `process_knowledge_graph` run would skip the article and leave the graph attached to the old body. Fix: in-transaction `UPDATE article_hypergraph SET processing_status = 'failed' WHERE feed_item_id = ?` after the upsert. Fresh ingests have no row yet so the UPDATE matches zero (no behavioral change). Two new tests cover the fresh-ingest no-op and the upsert-requeue paths. **Note**: this requeues the article but does not clean up orphan edges/nodes from the prior body — that's tracked in issue #32.
- **36d635a51** — *Project: set development team and Apple Development signing identity*. `DEVELOPMENT_TEAM = 6CGNH3LTV7`, `CODE_SIGN_IDENTITY[sdk=macosx*] = \"Apple Development\"`, `INFOPLIST_KEY_NSDocumentsFolderUsageDescription` set so the TCC prompt on first `~/Documents` access shows a meaningful explanation. Local-build only — `release.yml` still passes `CODE_SIGN_IDENTITY=\"-\"` on the `xcodebuild -exportArchive` command line, so end-user downloads from GitHub Releases are unaffected.

## Test plan

- [x] All 19 ArticleIngestionServiceTests pass (verified locally with `CODE_SIGNING_ALLOWED=NO`).
- [x] CI lint passes.
- [x] CI build of legacy SwiftPM target passes (the `Database.current` shim from `11faa9f57` keeps it compiling).
- [ ] Smoke test in app: create a manual feed via MCP, ingest an article, verify it appears in the UI, re-ingest with same guid, verify article_hypergraph status flipped to failed and the next process run picks it up.