### PR TITLE
Settings: move cluster labeling system prompt to app_settings

### DIFF
--- a/NewsCombApp/Models/AppSettings.swift
+++ b/NewsCombApp/Models/AppSettings.swift
@@ -151,6 +151,9 @@ extension AppSettings {
     static let extractionSystemPrompt = "extraction_system_prompt"
     static let distillationSystemPrompt = "distillation_system_prompt"
 
+    // Theme Clustering Prompts
+    static let clusterLabelingSystemPrompt = "cluster_labeling_system_prompt"
+
     // Deep Analysis Agent Prompts
     static let engineerAgentPrompt = "engineer_agent_prompt"
     static let hypothesizerAgentPrompt = "hypothesizer_agent_prompt"
@@ -228,6 +231,37 @@ extension AppSettings {
     - Speculation or opinion
 
     Preserve technical terms, product names, and company names exactly as written.
+    """
+
+    /// Default cluster labeling prompt — produces a title + paragraph summary for each story theme cluster.
+    static let defaultClusterLabelingPrompt = """
+    You write concise, fact-dense summaries of news themes. You receive data \
+    extracted from multiple news articles that were automatically grouped together. \
+    Your job is to describe what is actually happening — who did what, to whom, \
+    and what was announced, decided, or discovered.
+
+    You will receive:
+    - Key entities (people, companies, products)
+    - Types of relationships between them
+    - Representative events in Subject-Verb-Object form, with source context \
+    from the original article text when available
+    - Source article headlines and publisher descriptions
+
+    Writing rules:
+    - Title: a specific, factual headline (under 10 words). Name the main actor \
+    or subject if one dominates. Do NOT start with a gerund.
+    - Summary: 2-5 sentences packed with specifics — names, products, numbers, \
+    actions. Lead with the most concrete fact, not a meta-description.
+    - NEVER start with "This topic", "This theme", "This cluster", or any \
+    third-person reference to the grouping itself. Jump straight into the facts.
+    - Name the actors and their actions. "AWS launched SageMaker Inference for \
+    custom Nova models" is good. "New infrastructure for deploying AI" is bad.
+    - If the grouped items share a clear thread, describe it. If they are loosely \
+    related or span several sub-topics, briefly list the key items rather than \
+    forcing a single narrative. Honesty about breadth beats false coherence.
+    - Only state facts present in the provided data.
+
+    Output EXACTLY this JSON: {"title": "...", "summary": "..."}
     """
 
     // MARK: - On-Device (Foundation Models) Settings

--- a/NewsCombApp/Services/ClusterLabelingService.swift
+++ b/NewsCombApp/Services/ClusterLabelingService.swift
@@ -19,38 +19,6 @@ final class ClusterLabelingService: Sendable {
     private let database = Database.current
     private let logger = Logger(subsystem: "com.newscomb", category: "ClusterLabelingService")
 
-    // MARK: - System Prompt
-
-    private static let systemPrompt = """
-        You write concise, fact-dense summaries of news themes. You receive data \
-        extracted from multiple news articles that were automatically grouped together. \
-        Your job is to describe what is actually happening — who did what, to whom, \
-        and what was announced, decided, or discovered.
-
-        You will receive:
-        - Key entities (people, companies, products)
-        - Types of relationships between them
-        - Representative events in Subject-Verb-Object form, with source context \
-        from the original article text when available
-        - Source article headlines and publisher descriptions
-
-        Writing rules:
-        - Title: a specific, factual headline (under 10 words). Name the main actor \
-        or subject if one dominates. Do NOT start with a gerund.
-        - Summary: 2-5 sentences packed with specifics — names, products, numbers, \
-        actions. Lead with the most concrete fact, not a meta-description.
-        - NEVER start with "This topic", "This theme", "This cluster", or any \
-        third-person reference to the grouping itself. Jump straight into the facts.
-        - Name the actors and their actions. "AWS launched SageMaker Inference for \
-        custom Nova models" is good. "New infrastructure for deploying AI" is bad.
-        - If the grouped items share a clear thread, describe it. If they are loosely \
-        related or span several sub-topics, briefly list the key items rather than \
-        forcing a single narrative. Honesty about breadth beats false coherence.
-        - Only state facts present in the provided data.
-
-        Output EXACTLY this JSON: {"title": "...", "summary": "..."}
-        """
-
     // MARK: - Public API
 
     /// Generates LLM titles and summaries for all clusters in a build.
@@ -127,7 +95,7 @@ final class ClusterLabelingService: Sendable {
                                 exemplars: exemplars
                             )
                             let response = try await self.callLLM(
-                                systemPrompt: Self.systemPrompt,
+                                systemPrompt: settings.clusterLabelingPrompt ?? AppSettings.defaultClusterLabelingPrompt,
                                 userPrompt: userPrompt,
                                 settings: settings
                             )
@@ -510,6 +478,13 @@ final class ClusterLabelingService: Sendable {
                 .filter(AppSettings.Columns.key == AppSettings.analysisOpenRouterModel)
                 .fetchOne(db) {
                 settings.analysisOpenRouterModel = model.value
+            }
+
+            // Cluster-labeling system prompt (falls back to AppSettings.defaultClusterLabelingPrompt at the call site when nil)
+            if let prompt = try AppSettings
+                .filter(AppSettings.Columns.key == AppSettings.clusterLabelingSystemPrompt)
+                .fetchOne(db) {
+                settings.clusterLabelingPrompt = prompt.value
             }
 
             return settings

--- a/NewsCombApp/Services/DatabaseService.swift
+++ b/NewsCombApp/Services/DatabaseService.swift
@@ -730,6 +730,7 @@ public final class Database: Sendable {
             // Prompts
             (AppSettings.extractionSystemPrompt, AppSettings.defaultExtractionPrompt),
             (AppSettings.distillationSystemPrompt, AppSettings.defaultDistillationPrompt),
+            (AppSettings.clusterLabelingSystemPrompt, AppSettings.defaultClusterLabelingPrompt),
             (AppSettings.engineerAgentPrompt, AppSettings.defaultEngineerAgentPrompt),
             (AppSettings.hypothesizerAgentPrompt, AppSettings.defaultHypothesizerAgentPrompt),
 

--- a/NewsCombApp/Services/HypergraphService.swift
+++ b/NewsCombApp/Services/HypergraphService.swift
@@ -1271,6 +1271,7 @@ struct LLMSettings: Sendable {
     // Custom prompts (nil means use defaults)
     var extractionSystemPrompt: String?
     var distillationSystemPrompt: String?
+    var clusterLabelingPrompt: String?
 
     // MARK: - Analysis LLM Helpers
 

--- a/NewsCombApp/ViewModels/SettingsViewModel.swift
+++ b/NewsCombApp/ViewModels/SettingsViewModel.swift
@@ -120,6 +120,9 @@ class SettingsViewModel {
     var extractionSystemPrompt: String = AppSettings.defaultExtractionPrompt
     var distillationSystemPrompt: String = AppSettings.defaultDistillationPrompt
 
+    // Theme Clustering Prompt
+    var clusterLabelingSystemPrompt: String = AppSettings.defaultClusterLabelingPrompt
+
     // Deep Analysis Agent Prompts
     var engineerAgentPrompt: String = AppSettings.defaultEngineerAgentPrompt
     var hypothesizerAgentPrompt: String = AppSettings.defaultHypothesizerAgentPrompt
@@ -335,6 +338,10 @@ class SettingsViewModel {
 
                 if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.distillationSystemPrompt).fetchOne(db) {
                     distillationSystemPrompt = setting.value
+                }
+
+                if let setting = try AppSettings.filter(AppSettings.Columns.key == AppSettings.clusterLabelingSystemPrompt).fetchOne(db) {
+                    clusterLabelingSystemPrompt = setting.value
                 }
 
                 // Load deep analysis agent prompts
@@ -733,6 +740,17 @@ class SettingsViewModel {
     func resetDistillationPromptToDefault() {
         distillationSystemPrompt = AppSettings.defaultDistillationPrompt
         saveDistillationSystemPrompt()
+    }
+
+    // MARK: - Theme Clustering Prompt Save Methods
+
+    func saveClusterLabelingSystemPrompt() {
+        saveAPIKey(key: AppSettings.clusterLabelingSystemPrompt, value: clusterLabelingSystemPrompt)
+    }
+
+    func resetClusterLabelingPromptToDefault() {
+        clusterLabelingSystemPrompt = AppSettings.defaultClusterLabelingPrompt
+        saveClusterLabelingSystemPrompt()
     }
 
     // MARK: - Deep Analysis Agent Prompts Save Methods

--- a/NewsCombApp/Views/SettingsView.swift
+++ b/NewsCombApp/Views/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
             knowledgeExtractionSection
             analysisModelSection
             algorithmParametersSection
+            clusterLabelingPromptSection
             extractionPromptsSection
             deepAnalysisPromptsSection
             socialSimulationSection
@@ -490,6 +491,38 @@ struct SettingsView: View {
             Text("Algorithm Parameters")
         } footer: {
             Text("Fine-tune knowledge extraction, node merging, and query parameters.")
+        }
+    }
+
+    private var clusterLabelingPromptSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Cluster Labeling Prompt")
+                        .font(.headline)
+                    Spacer()
+                    Button("Reset to Default") {
+                        viewModel.resetClusterLabelingPromptToDefault()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.blue)
+                }
+
+                TextEditor(text: $viewModel.clusterLabelingSystemPrompt)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 160)
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(.rect(cornerRadius: 8))
+                    .onChange(of: viewModel.clusterLabelingSystemPrompt) {
+                        viewModel.saveClusterLabelingSystemPrompt()
+                    }
+            }
+        } header: {
+            Text("Theme Clustering")
+        } footer: {
+            Text("Used by the analysis LLM at the end of theme clustering to give each cluster a title and one-paragraph summary. Edit for non-news corpora (docs, codebases, scientific or legal text) where the news framing produces awkward labels.")
         }
     }
 

--- a/NewsCombAppTests/ClusterLabelingServiceTests.swift
+++ b/NewsCombAppTests/ClusterLabelingServiceTests.swift
@@ -1,9 +1,97 @@
 import XCTest
+import GRDB
 @testable import NewsCombApp
 
 final class ClusterLabelingServiceTests: XCTestCase {
 
     private let service = ClusterLabelingService()
+
+    // MARK: - System Prompt Configurability
+
+    func testClusterLabelingSystemPromptKey() {
+        XCTAssertEqual(
+            AppSettings.clusterLabelingSystemPrompt,
+            "cluster_labeling_system_prompt",
+            "Settings key must stay stable — changing it orphans existing user overrides in workspaces."
+        )
+    }
+
+    func testDefaultClusterLabelingPromptHasExpectedContent() {
+        let prompt = AppSettings.defaultClusterLabelingPrompt
+        XCTAssertFalse(prompt.isEmpty, "Default cluster labeling prompt must not be empty")
+        XCTAssertTrue(
+            prompt.contains("title"),
+            "Prompt must instruct the LLM to produce a title field"
+        )
+        XCTAssertTrue(
+            prompt.contains("summary"),
+            "Prompt must instruct the LLM to produce a summary field"
+        )
+        XCTAssertTrue(
+            prompt.contains("{\"title\": \"...\", \"summary\": \"...\"}"),
+            "Prompt must specify the exact JSON shape the parser expects"
+        )
+    }
+
+    func testLLMSettingsClusterLabelingPromptDefaultsToNil() {
+        let settings = LLMSettings()
+        XCTAssertNil(
+            settings.clusterLabelingPrompt,
+            "Field defaults to nil so call sites fall back to AppSettings.defaultClusterLabelingPrompt"
+        )
+    }
+
+    func testLLMSettingsCarriesClusterLabelingOverride() {
+        var settings = LLMSettings()
+        settings.clusterLabelingPrompt = "custom override"
+        XCTAssertEqual(settings.clusterLabelingPrompt, "custom override")
+    }
+
+    func testClusterLabelingPromptRoundTripsThroughInMemoryDB() throws {
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE app_settings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT NOT NULL UNIQUE,
+                    value TEXT NOT NULL
+                )
+            """)
+            try db.execute(
+                sql: "INSERT INTO app_settings (key, value) VALUES (?, ?)",
+                arguments: [AppSettings.clusterLabelingSystemPrompt, "Custom labeling instructions for codebase corpus."]
+            )
+        }
+
+        try dbQueue.read { db in
+            let setting = try AppSettings
+                .filter(AppSettings.Columns.key == AppSettings.clusterLabelingSystemPrompt)
+                .fetchOne(db)
+            XCTAssertEqual(setting?.value, "Custom labeling instructions for codebase corpus.")
+        }
+    }
+
+    func testClusterLabelingPromptMissingRowReturnsNil() throws {
+        // When no row exists for the key, AppSettings.filter returns nil and the
+        // service falls back to AppSettings.defaultClusterLabelingPrompt at the call site.
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE app_settings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT NOT NULL UNIQUE,
+                    value TEXT NOT NULL
+                )
+            """)
+        }
+
+        try dbQueue.read { db in
+            let setting = try AppSettings
+                .filter(AppSettings.Columns.key == AppSettings.clusterLabelingSystemPrompt)
+                .fetchOne(db)
+            XCTAssertNil(setting)
+        }
+    }
 
     // MARK: - parseResponse Tests
 


### PR DESCRIPTION
## Summary

- Move the cluster-labeling system prompt out of a `private static let` in `ClusterLabelingService` and into a workspace-scoped `app_settings` row (`cluster_labeling_system_prompt`), editable from a TextEditor under "Theme Clustering" in Settings.
- Default text is byte-identical to the previous static, so behavior is unchanged when the default is used. Non-news corpora (codebases, scientific or legal text) can now swap the prompt without a rebuild.
- Mirrors the existing pattern for the extraction and distillation prompts — same `defaultClusterLabelingPrompt` / load / save / reset shape, same DatabaseService default seeding, same SettingsViewModel wiring; the new `clusterLabelingPrompt: String?` field on the shared `LLMSettings` struct is the carrier.

Closes #34

## Test plan

- [x] `xcodebuild test -scheme NewsCombApp -destination 'platform=macOS' -only-testing:NewsCombAppTests/ClusterLabelingServiceTests CODE_SIGNING_ALLOWED=NO` — 21 cases pass, including 6 new ones covering the AppSettings key, default content, the new `LLMSettings.clusterLabelingPrompt` field, fall-back-to-default when no row exists, and round-trip persistence in an in-memory DB.
- [x] Full `HypergraphServiceTests` + `ClusterLabelingServiceTests` run together against the merged tree — 49 cases pass, confirming the merge with #33's distillation toggle (which touches the same five files) did not regress.
- [ ] Manual: open Settings → Theme Clustering, edit the TextEditor, kick off a theme rebuild, confirm the new prompt reaches the LLM via Console.app (`com.newscomb / ClusterLabelingService`).
- [ ] Manual: tap "Reset to Default" and confirm the seeded text reappears in the editor and is persisted to `app_settings`.