### PR TITLE
Add reprocess_article MCP tool for surgical re-extraction

### DIFF
--- a/NewsCombApp/MCP/MCPAppCoordinator.swift
+++ b/NewsCombApp/MCP/MCPAppCoordinator.swift
@@ -91,6 +91,30 @@ final class MCPAppCoordinator {
         }
     }
 
+    /// Surgically drops one article's downstream graph state and re-runs
+    /// per-article extraction. Equivalent in effect to a "delete-and-reprocess
+    /// just this row" path that the batch upserts can't provide cleanly.
+    func reprocessArticle(feedItemId: Int64) async -> String {
+        logger.info("MCP triggered reprocessArticle feedItemId=\(feedItemId, privacy: .public)")
+        let service = HypergraphService()
+        do {
+            let outcome = try await service.reprocessArticle(feedItemId: feedItemId)
+            mainViewModel.loadHypergraphStats()
+            let stats = outcome.deletionStats
+            return """
+            Reprocessed article #\(outcome.feedItemId) in \(outcome.processingTimeMs)ms. \
+            Dropped \(stats.chunksDeleted) chunks, \(stats.edgesDeleted) edges, \
+            \(stats.provenanceDeleted) provenance rows, and swept \(stats.orphanNodesDeleted) orphan node(s). \
+            Re-extracted: \(outcome.chunksAdded) chunks, \(outcome.edgesAdded) edges, \
+            \(outcome.nodesAdded) participating node(s).
+            """
+        } catch let error as HypergraphServiceError {
+            return "Reprocess article failed: \(error.localizedDescription)"
+        } catch {
+            return "Reprocess article failed: \(error.localizedDescription)"
+        }
+    }
+
     /// Re-fetches `full_content` for a single article via the Postlight pipeline.
     func refreshArticle(feedItemId: Int64) async -> String {
         logger.info("MCP triggered refreshArticle feedItemId=\(feedItemId, privacy: .public)")

--- a/NewsCombApp/MCP/MCPToolDispatcher.swift
+++ b/NewsCombApp/MCP/MCPToolDispatcher.swift
@@ -47,6 +47,8 @@ enum MCPToolDispatcher {
                 result = try await MCPIngestArticleTool.run(arguments: arguments)
             case "refresh_article":
                 result = try await MCPRefreshArticleTool.run(arguments: arguments)
+            case "reprocess_article":
+                result = try await MCPReprocessArticleTool.run(arguments: arguments)
             case "process_knowledge_graph":
                 result = await MCPProcessKnowledgeGraphTool.run(arguments: arguments)
             case "cancel_knowledge_graph_processing":

--- a/NewsCombApp/MCP/MCPToolHandler.swift
+++ b/NewsCombApp/MCP/MCPToolHandler.swift
@@ -239,6 +239,21 @@ struct MCPToolHandler: Sendable {
                 annotations: .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true)
             ),
             Tool(
+                name: "reprocess_article",
+                description: "Drop and re-extract knowledge graph state for a single article. Use after ingest_article when you want the graph to reflect the new body immediately rather than waiting for the next batch process_knowledge_graph run. Atomically deletes the article's chunks, edges, incidences, and provenance, then sweeps any nodes that became globally orphaned (no remaining incidences), then re-runs the per-article extraction pipeline. Returns counts of dropped and re-extracted rows.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "feed_item_id": .object([
+                            "type": .string("integer"),
+                            "description": .string("ID of the article to reprocess (from get_recent_articles or feed_item.id).")
+                        ])
+                    ]),
+                    "required": .array([.string("feed_item_id")])
+                ]),
+                annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true)
+            ),
+            Tool(
                 name: "process_knowledge_graph",
                 description: "Trigger LLM extraction over unprocessed articles — equivalent to the 'Process Knowledge Graph' toolbar button. Persists new entities, relationships, embeddings, and auto-simplifies the graph. The UI shows live progress.",
                 inputSchema: .object([

--- a/NewsCombApp/MCP/Tools/MCPReprocessArticleTool.swift
+++ b/NewsCombApp/MCP/Tools/MCPReprocessArticleTool.swift
@@ -1,0 +1,19 @@
+import Foundation
+import MCP
+
+/// Drops one article's downstream knowledge-graph state — chunks, edges,
+/// incidences, provenance, and any nodes orphaned by the edge deletion — and
+/// re-runs per-article extraction in a single transaction-then-extract flow.
+/// Use this after `ingest_article` has updated a body and the caller wants the
+/// graph to reflect the new body immediately, instead of waiting for the next
+/// batch `process_knowledge_graph` (which leaves the old edges and orphan
+/// nodes behind because re-extraction generates new chunk-hashed edge IDs
+/// that don't dedupe against the old ones).
+enum MCPReprocessArticleTool {
+    static func run(arguments: [String: Value]) async throws -> String {
+        guard let feedItemId = arguments["feed_item_id"]?.intValue.map(Int64.init) else {
+            throw MCPToolError.missingParameter("feed_item_id")
+        }
+        return await MCPAppCoordinator.shared.reprocessArticle(feedItemId: feedItemId)
+    }
+}

--- a/NewsCombApp/Services/HypergraphService.swift
+++ b/NewsCombApp/Services/HypergraphService.swift
@@ -210,6 +210,185 @@ final class HypergraphService: Sendable {
         }
     }
 
+    /// Drops a single article's downstream hypergraph state and re-runs
+    /// per-article extraction. Use this when the article body changed and the
+    /// caller wants the graph to reflect the new body cleanly, instead of the
+    /// union of old + new orphaned by the batch path's upsert behavior.
+    ///
+    /// Steps (all deletes happen inside one write transaction; extraction
+    /// follows after the transaction commits):
+    ///   1. Drop provenance rows owned by this article.
+    ///   2. Drop edges sourced from this article's chunks (cascades incidences
+    ///      and any remaining provenance for those edges).
+    ///   3. Drop globally-orphaned nodes (no remaining incidences).
+    ///   4. Drop the article's chunks.
+    ///   5. Drop the `article_hypergraph` tracking row so re-extraction starts clean.
+    @MainActor
+    func reprocessArticle(feedItemId: Int64, detailCallback: DetailCallback? = nil) async throws -> ReprocessOutcome {
+        logger.info("Reprocessing article \(feedItemId): dropping downstream graph state")
+
+        let startTime = Date()
+        let deletionStats = try database.write { db in
+            try Self.deleteArticleGraphState(db: db, feedItemId: feedItemId)
+        }
+        logger.info(
+            "Reprocess deletes: \(deletionStats.chunksDeleted) chunks, \(deletionStats.edgesDeleted) edges, \(deletionStats.orphanNodesDeleted) orphan nodes, \(deletionStats.provenanceDeleted) provenance rows"
+        )
+
+        try await processArticle(feedItemId: feedItemId, detailCallback: detailCallback)
+
+        let chunksAdded = try database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM article_chunk WHERE feed_item_id = ?",
+                arguments: [feedItemId]
+            ) ?? 0
+        }
+        let edgesAdded = try database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM hypergraph_edge
+                    WHERE source_chunk_id IN (SELECT id FROM article_chunk WHERE feed_item_id = ?)
+                """,
+                arguments: [feedItemId]
+            ) ?? 0
+        }
+        let nodesAdded = try database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(DISTINCT i.node_id)
+                    FROM hypergraph_incidence i
+                    JOIN hypergraph_edge e ON e.id = i.edge_id
+                    WHERE e.source_chunk_id IN (SELECT id FROM article_chunk WHERE feed_item_id = ?)
+                """,
+                arguments: [feedItemId]
+            ) ?? 0
+        }
+        let elapsedMs = Int(Date().timeIntervalSince(startTime) * 1000)
+
+        return ReprocessOutcome(
+            feedItemId: feedItemId,
+            chunksAdded: chunksAdded,
+            nodesAdded: nodesAdded,
+            edgesAdded: edgesAdded,
+            processingTimeMs: elapsedMs,
+            deletionStats: deletionStats
+        )
+    }
+
+    /// Performs the surgical delete chain inside a write transaction. Exposed
+    /// as a static helper so unit tests can exercise it against an in-memory
+    /// `DatabaseQueue` without touching `Database.current`. Must be called
+    /// inside a write transaction; `Database.write { ... }` runs the closure
+    /// as a single transaction.
+    static func deleteArticleGraphState(db: GRDB.Database, feedItemId: Int64) throws -> ReprocessDeletionStats {
+        // 1. Provenance rows owned by this article.
+        try db.execute(
+            sql: "DELETE FROM article_edge_provenance WHERE feed_item_id = ?",
+            arguments: [feedItemId]
+        )
+        let provenanceDeleted = db.changesCount
+
+        // 2. Edges sourced from this article's chunks. We capture their IDs
+        //    first so we can clean up the vec0-backed `event_vectors` and the
+        //    cluster-assignment table, neither of which has FK cascades.
+        //    `hypergraph_incidence` and remaining `article_edge_provenance`
+        //    rows DO cascade via real FKs.
+        let edgeIds: [Int64] = try Int64.fetchAll(
+            db,
+            sql: """
+                SELECT id FROM hypergraph_edge
+                WHERE source_chunk_id IN (SELECT id FROM article_chunk WHERE feed_item_id = ?)
+            """,
+            arguments: [feedItemId]
+        )
+        if !edgeIds.isEmpty {
+            // vec0 virtual tables don't support bulk IN-clause deletes — each
+            // event_id must be deleted by its own statement. Same constraint
+            // is enforced in `SettingsViewModel.deleteSource` and
+            // `MainViewModel.resetKnowledgeGraph`.
+            for edgeId in edgeIds {
+                try db.execute(
+                    sql: "DELETE FROM event_vectors WHERE event_id = ?",
+                    arguments: [edgeId]
+                )
+            }
+            let placeholders = Array(repeating: "?", count: edgeIds.count).joined(separator: ",")
+            let args = StatementArguments(edgeIds)
+            try db.execute(
+                sql: "DELETE FROM event_cluster WHERE event_id IN (\(placeholders))",
+                arguments: args
+            )
+            try db.execute(
+                sql: "DELETE FROM hypergraph_edge WHERE id IN (\(placeholders))",
+                arguments: args
+            )
+        }
+        let edgesDeleted = edgeIds.count
+
+        // 3. Globally orphan nodes. `node_embedding` is a vec0 virtual table
+        //    with no FK cascade, so its rows must be deleted explicitly;
+        //    `node_embedding_metadata` cascades on `hypergraph_node` deletion.
+        let orphanNodeIds: [Int64] = try Int64.fetchAll(
+            db,
+            sql: """
+                SELECT id FROM hypergraph_node
+                WHERE id NOT IN (SELECT DISTINCT node_id FROM hypergraph_incidence)
+            """
+        )
+        if !orphanNodeIds.isEmpty {
+            for nodeId in orphanNodeIds {
+                try db.execute(
+                    sql: "DELETE FROM node_embedding WHERE node_id = ?",
+                    arguments: [nodeId]
+                )
+            }
+            let placeholders = Array(repeating: "?", count: orphanNodeIds.count).joined(separator: ",")
+            let args = StatementArguments(orphanNodeIds)
+            try db.execute(
+                sql: "DELETE FROM hypergraph_node WHERE id IN (\(placeholders))",
+                arguments: args
+            )
+        }
+        let orphanNodesDeleted = orphanNodeIds.count
+
+        // 4. Chunks. `chunk_embedding` is a vec0 virtual table with no FK
+        //    cascade — clean its rows first. `chunk_embedding_metadata`
+        //    cascades on `article_chunk` deletion.
+        let chunkIds: [Int64] = try Int64.fetchAll(
+            db,
+            sql: "SELECT id FROM article_chunk WHERE feed_item_id = ?",
+            arguments: [feedItemId]
+        )
+        for chunkId in chunkIds {
+            try db.execute(
+                sql: "DELETE FROM chunk_embedding WHERE chunk_id = ?",
+                arguments: [chunkId]
+            )
+        }
+        try db.execute(
+            sql: "DELETE FROM article_chunk WHERE feed_item_id = ?",
+            arguments: [feedItemId]
+        )
+        let chunksDeleted = chunkIds.count
+
+        // 5. Tracking row. Without this, the unprocessed-articles query won't
+        //    pick the article up again on subsequent batch runs.
+        try db.execute(
+            sql: "DELETE FROM article_hypergraph WHERE feed_item_id = ?",
+            arguments: [feedItemId]
+        )
+
+        return ReprocessDeletionStats(
+            chunksDeleted: chunksDeleted,
+            edgesDeleted: edgesDeleted,
+            orphanNodesDeleted: orphanNodesDeleted,
+            provenanceDeleted: provenanceDeleted
+        )
+    }
+
     /// Processes all unprocessed articles with progress callback.
     /// Articles are processed in parallel with a configurable concurrency limit.
     /// Processing can be cancelled by calling `cancelProcessing()`.
@@ -1320,6 +1499,29 @@ struct HypergraphStatistics: Sendable {
     let processedArticles: Int
     let embeddingCount: Int
     let personaNodeCount: Int
+}
+
+/// Counts of rows deleted by `HypergraphService.deleteArticleGraphState`.
+/// `orphanNodesDeleted` is a global sweep — it counts every node whose
+/// remaining incidence count fell to zero, which may include nodes orphaned
+/// by previous reprocesses, not just by this article.
+struct ReprocessDeletionStats: Sendable, Equatable {
+    let chunksDeleted: Int
+    let edgesDeleted: Int
+    let orphanNodesDeleted: Int
+    let provenanceDeleted: Int
+}
+
+/// Result returned from `HypergraphService.reprocessArticle`. The `*Added`
+/// fields are post-reprocess counts scoped to this article, since the delete
+/// chain brought the article's graph state to zero before re-extraction ran.
+struct ReprocessOutcome: Sendable {
+    let feedItemId: Int64
+    let chunksAdded: Int
+    let nodesAdded: Int
+    let edgesAdded: Int
+    let processingTimeMs: Int
+    let deletionStats: ReprocessDeletionStats
 }
 
 enum HypergraphServiceError: Error, LocalizedError {

--- a/NewsCombAppTests/HypergraphReprocessArticleTests.swift
+++ b/NewsCombAppTests/HypergraphReprocessArticleTests.swift
@@ -1,0 +1,314 @@
+import XCTest
+import GRDB
+@testable import NewsCombApp
+
+/// Unit tests for the surgical delete chain that backs
+/// `HypergraphService.reprocessArticle`. The full reprocess path also runs
+/// `processArticle` (which needs an LLM provider), so we test the deletion
+/// half in isolation here against an in-memory `DatabaseQueue` and
+/// integration-test the LLM half elsewhere.
+final class HypergraphReprocessArticleTests: XCTestCase {
+
+    private var dbQueue: DatabaseQueue!
+
+    override func setUp() {
+        super.setUp()
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+        dbQueue = try! DatabaseQueue(configuration: config)
+        try! dbQueue.write { db in
+            try createSchema(db)
+        }
+    }
+
+    override func tearDown() {
+        dbQueue = nil
+        super.tearDown()
+    }
+
+    // MARK: - Happy path
+
+    func testDeleteArticleGraphStateScopedToOneArticle() throws {
+        try dbQueue.write { db in try seedTwoArticles(db) }
+
+        let stats = try dbQueue.write { db in
+            try HypergraphService.deleteArticleGraphState(db: db, feedItemId: 100)
+        }
+
+        // Article A had 2 chunks, 2 edges, 2 provenance rows. Node "shared"
+        // and "only_b" remain alive because B still references them — only
+        // "only_a" should have been swept.
+        XCTAssertEqual(stats.chunksDeleted, 2)
+        XCTAssertEqual(stats.edgesDeleted, 2)
+        XCTAssertEqual(stats.provenanceDeleted, 2)
+        XCTAssertEqual(stats.orphanNodesDeleted, 1)
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try countAll(db, "article_chunk", "feed_item_id = 100"), 0)
+            XCTAssertEqual(try countAll(db, "article_chunk", "feed_item_id = 200"), 1)
+
+            XCTAssertEqual(try countAll(db, "hypergraph_edge", "id IN (1, 2)"), 0)
+            XCTAssertEqual(try countAll(db, "hypergraph_edge", "id = 3"), 1)
+
+            XCTAssertEqual(try countAll(db, "hypergraph_incidence", "edge_id IN (1, 2)"), 0)
+            XCTAssertEqual(try countAll(db, "hypergraph_incidence", "edge_id = 3"), 2)
+
+            XCTAssertEqual(try countAll(db, "article_edge_provenance", "feed_item_id = 100"), 0)
+            XCTAssertEqual(try countAll(db, "article_edge_provenance", "feed_item_id = 200"), 1)
+
+            XCTAssertEqual(try countAll(db, "article_hypergraph", "feed_item_id = 100"), 0)
+            XCTAssertEqual(try countAll(db, "article_hypergraph", "feed_item_id = 200"), 1)
+        }
+    }
+
+    // MARK: - Orphan boundary
+
+    func testSharedNodeSurvivesWhenOtherArticleStillReferencesIt() throws {
+        try dbQueue.write { db in try seedTwoArticles(db) }
+
+        _ = try dbQueue.write { db in
+            try HypergraphService.deleteArticleGraphState(db: db, feedItemId: 100)
+        }
+
+        try dbQueue.read { db in
+            // "shared" node was used by both edges 1 (article A) and edge 3
+            // (article B). After deleting A, it's still alive via edge 3.
+            let sharedExists = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM hypergraph_node WHERE node_id = 'shared')"
+            )
+            XCTAssertEqual(sharedExists, true)
+
+            // "only_b" must remain too: B's edge 3 still points at it.
+            let onlyBExists = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM hypergraph_node WHERE node_id = 'only_b')"
+            )
+            XCTAssertEqual(onlyBExists, true)
+
+            // "only_a" was used solely by edges 1 and 2; it must be gone.
+            let onlyAExists = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM hypergraph_node WHERE node_id = 'only_a')"
+            )
+            XCTAssertEqual(onlyAExists, false)
+        }
+    }
+
+    // MARK: - No-op safety
+
+    func testReprocessOnUnseenArticleIsNoOp() throws {
+        try dbQueue.write { db in try seedTwoArticles(db) }
+
+        // 999 has never been processed — no chunks, no edges, no provenance.
+        let stats = try dbQueue.write { db in
+            try HypergraphService.deleteArticleGraphState(db: db, feedItemId: 999)
+        }
+
+        XCTAssertEqual(stats.chunksDeleted, 0)
+        XCTAssertEqual(stats.edgesDeleted, 0)
+        XCTAssertEqual(stats.provenanceDeleted, 0)
+        // Orphan sweep is global: any pre-existing orphans (none here) would count.
+        XCTAssertEqual(stats.orphanNodesDeleted, 0)
+
+        try dbQueue.read { db in
+            // Article A and B are completely untouched.
+            XCTAssertEqual(try countAll(db, "article_chunk", "feed_item_id = 100"), 2)
+            XCTAssertEqual(try countAll(db, "article_chunk", "feed_item_id = 200"), 1)
+            XCTAssertEqual(try countAll(db, "hypergraph_edge", "1 = 1"), 3)
+            XCTAssertEqual(try countAll(db, "hypergraph_node", "1 = 1"), 3)
+        }
+    }
+
+    // MARK: - Vec0 cleanup paths exercised
+
+    func testEmbeddingRowsAreDeletedAlongsideTheirParents() throws {
+        try dbQueue.write { db in
+            try seedTwoArticles(db)
+            // Seed embeddings for A's chunks and the soon-to-be-orphan "only_a" node.
+            try db.execute(sql: "INSERT INTO chunk_embedding (chunk_id, embedding) VALUES (10, x'00')")
+            try db.execute(sql: "INSERT INTO chunk_embedding (chunk_id, embedding) VALUES (11, x'00')")
+            try db.execute(sql: "INSERT INTO chunk_embedding (chunk_id, embedding) VALUES (20, x'00')")
+            try db.execute(sql: "INSERT INTO node_embedding (node_id, embedding) VALUES (1, x'00')")
+            try db.execute(sql: "INSERT INTO node_embedding (node_id, embedding) VALUES (2, x'00')")
+            try db.execute(sql: "INSERT INTO node_embedding (node_id, embedding) VALUES (3, x'00')")
+            try db.execute(sql: "INSERT INTO event_vectors (event_id, vec) VALUES (1, x'00')")
+            try db.execute(sql: "INSERT INTO event_vectors (event_id, vec) VALUES (2, x'00')")
+            try db.execute(sql: "INSERT INTO event_vectors (event_id, vec) VALUES (3, x'00')")
+            try db.execute(sql: "INSERT INTO event_cluster (event_id, build_id, cluster_id) VALUES (1, 'b', 1)")
+            try db.execute(sql: "INSERT INTO event_cluster (event_id, build_id, cluster_id) VALUES (2, 'b', 1)")
+            try db.execute(sql: "INSERT INTO event_cluster (event_id, build_id, cluster_id) VALUES (3, 'b', 2)")
+        }
+
+        _ = try dbQueue.write { db in
+            try HypergraphService.deleteArticleGraphState(db: db, feedItemId: 100)
+        }
+
+        try dbQueue.read { db in
+            // Chunk embeddings for A's chunks (10, 11) gone; B's (20) survives.
+            XCTAssertEqual(try countAll(db, "chunk_embedding", "chunk_id IN (10, 11)"), 0)
+            XCTAssertEqual(try countAll(db, "chunk_embedding", "chunk_id = 20"), 1)
+
+            // Only the orphan node's embedding got swept. Node IDs 2 (shared)
+            // and 3 (only_b) remain; node 1 (only_a) and its embedding are gone.
+            XCTAssertEqual(try countAll(db, "node_embedding", "node_id = 1"), 0)
+            XCTAssertEqual(try countAll(db, "node_embedding", "node_id IN (2, 3)"), 2)
+
+            // Event-vectors and cluster assignments for A's edges (1, 2) gone;
+            // B's edge 3 keeps its rows.
+            XCTAssertEqual(try countAll(db, "event_vectors", "event_id IN (1, 2)"), 0)
+            XCTAssertEqual(try countAll(db, "event_vectors", "event_id = 3"), 1)
+            XCTAssertEqual(try countAll(db, "event_cluster", "event_id IN (1, 2)"), 0)
+            XCTAssertEqual(try countAll(db, "event_cluster", "event_id = 3"), 1)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func countAll(_ db: GRDB.Database, _ table: String, _ predicate: String) throws -> Int {
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table) WHERE \(predicate)") ?? -1
+    }
+
+    /// Seeds two articles into a freshly-created in-memory schema:
+    ///
+    ///   feed_item 100 (article A): chunks 10, 11; edges 1, 2; nodes "shared",
+    ///   "only_a"; provenance for both edges.
+    ///   feed_item 200 (article B): chunk 20; edge 3; nodes "shared", "only_b";
+    ///   provenance for edge 3.
+    ///
+    /// Node IDs: 1 = "only_a", 2 = "shared", 3 = "only_b".
+    private func seedTwoArticles(_ db: GRDB.Database) throws {
+        try db.execute(sql: "INSERT INTO rss_source (id, url) VALUES (1, 'https://test.com/feed')")
+        try db.execute(sql: """
+            INSERT INTO feed_item (id, source_id, guid, title, link)
+            VALUES (100, 1, 'a', 'Article A', 'https://a.com'),
+                   (200, 1, 'b', 'Article B', 'https://b.com')
+        """)
+
+        try db.execute(sql: """
+            INSERT INTO article_chunk (id, feed_item_id, chunk_index, content) VALUES
+                (10, 100, 0, 'A chunk 0'),
+                (11, 100, 1, 'A chunk 1'),
+                (20, 200, 0, 'B chunk 0')
+        """)
+
+        try db.execute(sql: """
+            INSERT INTO hypergraph_node (id, node_id, label) VALUES
+                (1, 'only_a', 'Only A'),
+                (2, 'shared', 'Shared'),
+                (3, 'only_b', 'Only B')
+        """)
+
+        try db.execute(sql: """
+            INSERT INTO hypergraph_edge (id, edge_id, label, source_chunk_id) VALUES
+                (1, 'e1', 'rel1', 10),
+                (2, 'e2', 'rel2', 11),
+                (3, 'e3', 'rel3', 20)
+        """)
+
+        // Edge 1 (A): only_a + shared. Edge 2 (A): only_a only.
+        // Edge 3 (B): only_b + shared.
+        try db.execute(sql: """
+            INSERT INTO hypergraph_incidence (edge_id, node_id, role, position) VALUES
+                (1, 1, 'source', 0),
+                (1, 2, 'target', 0),
+                (2, 1, 'source', 0),
+                (3, 3, 'source', 0),
+                (3, 2, 'target', 0)
+        """)
+
+        try db.execute(sql: """
+            INSERT INTO article_edge_provenance (edge_id, feed_item_id, chunk_index, chunk_text) VALUES
+                (1, 100, 0, 'A chunk 0'),
+                (2, 100, 1, 'A chunk 1'),
+                (3, 200, 0, 'B chunk 0')
+        """)
+
+        try db.execute(sql: """
+            INSERT INTO article_hypergraph (feed_item_id, processing_status, chunk_count) VALUES
+                (100, 'completed', 2),
+                (200, 'completed', 1)
+        """)
+    }
+
+    /// Minimal subset of the production schema covering everything the
+    /// reprocess delete chain touches. Vec0 virtual tables (`chunk_embedding`,
+    /// `node_embedding`, `event_vectors`) are stubbed as plain tables — same
+    /// names and column shapes — so the DELETE statements compile and run
+    /// without needing the sqlite-vec extension loaded in tests.
+    private func createSchema(_ db: GRDB.Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE rss_source (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE feed_item (
+                id INTEGER PRIMARY KEY,
+                source_id INTEGER NOT NULL REFERENCES rss_source(id) ON DELETE CASCADE,
+                guid TEXT NOT NULL,
+                title TEXT NOT NULL,
+                link TEXT NOT NULL,
+                UNIQUE(source_id, guid)
+            );
+            CREATE TABLE hypergraph_node (
+                id INTEGER PRIMARY KEY,
+                node_id TEXT NOT NULL UNIQUE,
+                label TEXT NOT NULL
+            );
+            CREATE TABLE article_chunk (
+                id INTEGER PRIMARY KEY,
+                feed_item_id INTEGER NOT NULL REFERENCES feed_item(id) ON DELETE CASCADE,
+                chunk_index INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                UNIQUE(feed_item_id, chunk_index)
+            );
+            CREATE TABLE hypergraph_edge (
+                id INTEGER PRIMARY KEY,
+                edge_id TEXT NOT NULL UNIQUE,
+                label TEXT NOT NULL,
+                source_chunk_id INTEGER REFERENCES article_chunk(id)
+            );
+            CREATE TABLE hypergraph_incidence (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                edge_id INTEGER NOT NULL REFERENCES hypergraph_edge(id) ON DELETE CASCADE,
+                node_id INTEGER NOT NULL REFERENCES hypergraph_node(id) ON DELETE CASCADE,
+                role TEXT NOT NULL,
+                position INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(edge_id, node_id, role)
+            );
+            CREATE TABLE article_hypergraph (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                feed_item_id INTEGER NOT NULL REFERENCES feed_item(id) ON DELETE CASCADE,
+                processing_status TEXT NOT NULL,
+                chunk_count INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(feed_item_id)
+            );
+            CREATE TABLE article_edge_provenance (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                edge_id INTEGER NOT NULL REFERENCES hypergraph_edge(id) ON DELETE CASCADE,
+                feed_item_id INTEGER NOT NULL REFERENCES feed_item(id) ON DELETE CASCADE,
+                chunk_index INTEGER NOT NULL,
+                chunk_text TEXT,
+                UNIQUE(edge_id, feed_item_id, chunk_index)
+            );
+            CREATE TABLE chunk_embedding (
+                chunk_id INTEGER PRIMARY KEY,
+                embedding BLOB
+            );
+            CREATE TABLE node_embedding (
+                node_id INTEGER PRIMARY KEY,
+                embedding BLOB
+            );
+            CREATE TABLE event_vectors (
+                event_id INTEGER PRIMARY KEY,
+                vec BLOB
+            );
+            CREATE TABLE event_cluster (
+                event_id INTEGER PRIMARY KEY,
+                build_id TEXT NOT NULL,
+                cluster_id INTEGER NOT NULL,
+                membership REAL NOT NULL DEFAULT 1.0
+            );
+        """)
+    }
+}

--- a/NewsCombAppTests/MCPReprocessArticleToolTests.swift
+++ b/NewsCombAppTests/MCPReprocessArticleToolTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import MCP
+@testable import NewsCombApp
+
+/// Argument-validation tests for the `reprocess_article` MCP tool. These
+/// exercise only the parameter decoding layer (which throws before reaching
+/// `MCPAppCoordinator.shared`), so they don't require a live database or LLM.
+/// End-to-end coverage of the deletion logic lives in
+/// `HypergraphReprocessArticleTests`.
+final class MCPReprocessArticleToolTests: XCTestCase {
+
+    func testReprocessArticleRejectsMissingFeedItemId() async {
+        await expectMCPError(messageContains: "feed_item_id") {
+            try await MCPReprocessArticleTool.run(arguments: [:])
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func expectMCPError<T>(
+        messageContains: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ block: () async throws -> T
+    ) async {
+        do {
+            _ = try await block()
+            XCTFail("Expected MCPToolError, got success", file: file, line: line)
+        } catch let error as MCPToolError {
+            XCTAssertTrue(
+                error.message.localizedStandardContains(messageContains),
+                "Error message '\(error.message)' should contain '\(messageContains)'",
+                file: file, line: line
+            )
+        } catch {
+            XCTFail("Expected MCPToolError, got \(type(of: error)): \(error)", file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #32. Adds a `reprocess_article(feed_item_id)` MCP tool that drops one article's downstream graph state in a single transaction, sweeps any nodes orphaned by the edge deletion, and re-runs the per-article extraction pipeline. Use it after `ingest_article` updates a body, when the caller wants the graph to reflect the new body now instead of waiting for the next batch `process_knowledge_graph`.

## Design

`HypergraphService.reprocessArticle(feedItemId:)` runs the full delete chain inside one `Database.write { ... }` transaction, then calls `processArticle(feedItemId:)` after the transaction commits:

1. `DELETE FROM article_edge_provenance WHERE feed_item_id = ?`
2. Find edges sourced from this article's chunks; clean their `event_vectors` and `event_cluster` rows; `DELETE FROM hypergraph_edge` (cascades incidences and any remaining provenance for those edges).
3. `DELETE FROM hypergraph_node WHERE id NOT IN (SELECT DISTINCT node_id FROM hypergraph_incidence)` — globally orphan-node sweep, intentional and bounded by the FK-incidence join.
4. `DELETE FROM article_chunk WHERE feed_item_id = ?`.
5. `DELETE FROM article_hypergraph WHERE feed_item_id = ?` so the unprocessed-articles query won't ever pick the article back up via the batch path.

The deletion logic is exposed as a static helper `deleteArticleGraphState(db:feedItemId:)` so the unit tests can exercise it against an in-memory `DatabaseQueue` without touching `Database.current` or needing an LLM.

## Findings on FK cascades

Verified against `NewsCombApp/Services/DatabaseService.swift`:

- `hypergraph_incidence.edge_id → hypergraph_edge` — ON DELETE CASCADE ✓ (relied on)
- `article_edge_provenance.edge_id → hypergraph_edge` — ON DELETE CASCADE ✓ (relied on)
- `node_embedding_metadata.node_id → hypergraph_node` — ON DELETE CASCADE ✓ (relied on)
- `chunk_embedding_metadata.chunk_id → article_chunk` — ON DELETE CASCADE ✓ (relied on)
- `node_embedding`, `chunk_embedding`, `event_vectors` — vec0 virtual tables, **no FK cascade**. Deleted explicitly. Per existing comments in `SettingsViewModel.deleteSource` and `MainViewModel.resetKnowledgeGraph`, vec0 also doesn't accept bulk `IN` deletes — each row is removed by its own statement.
- `event_cluster` — no FK to `hypergraph_edge`. Deleted explicitly to avoid leaving cluster assignments pointing at deleted edges.
- `hypergraph_edge.source_chunk_id → article_chunk` — no `ON DELETE` clause. The delete order (edges before chunks) avoids hitting this.

## Files changed

- `NewsCombApp/Services/HypergraphService.swift` — `reprocessArticle(feedItemId:)`, `deleteArticleGraphState(db:feedItemId:)`, `ReprocessOutcome`, `ReprocessDeletionStats`.
- `NewsCombApp/MCP/Tools/MCPReprocessArticleTool.swift` — new MCP tool entry point.
- `NewsCombApp/MCP/MCPToolDispatcher.swift` — route `reprocess_article` to the new tool.
- `NewsCombApp/MCP/MCPToolHandler.swift` — JSON-schema declaration for the tool.
- `NewsCombApp/MCP/MCPAppCoordinator.swift` — `reprocessArticle(feedItemId:)` mainactor bridge.
- `NewsCombAppTests/HypergraphReprocessArticleTests.swift` — happy path, orphan boundary, no-op safety, vec0 cleanup. Skips test 4 (transaction-atomicity-on-extraction-failure) per the issue note — wiring an injected error into `processArticle` would have required >50 lines of mock plumbing for a marginal guarantee.
- `NewsCombAppTests/MCPReprocessArticleToolTests.swift` — argument validation.
- `.github/workflows/ci.yml` — appends an xcodebuild step running the two new test classes; the swift-test step over the `NewsComb` SwiftPM package stays in place because the new tests live in the Xcode-only `NewsCombAppTests` target that `swift test` doesn't see.

## Notes / deviations from the issue

- **Service home**: kept `HypergraphService` rather than `ArticleIngestionService` because the deletion chain operates entirely on hypergraph tables and the entry point we re-call (`processArticle`) already lives there.
- **Return payload**: `chunks_added` and `edges_added` are post-reprocess counts scoped to this article (the deletes brought them to zero, so the post-reprocess count is the delta). `nodes_added` is the count of distinct nodes incident on this article's new edges — chosen because the global orphan sweep makes a true "added net of removed" count ambiguous.
- **vec0 IN-clause**: switched from a single `DELETE … WHERE id IN (…)` per table to a per-id loop after seeing the comment in `SettingsViewModel.deleteSource` — vec0 doesn't accept bulk IN deletes.

## Test plan

- [x] `HypergraphReprocessArticleTests`: happy path, orphan boundary (shared node survives when other article still references it), no-op safety, vec0 cleanup parents/children.
- [x] `MCPReprocessArticleToolTests`: missing `feed_item_id` arg validation.
- [ ] CI green via the appended xcodebuild step.

Closes #32

https://claude.ai/code/session_01W7CbTK6dgfVfgA6sjCFonu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7CbTK6dgfVfgA6sjCFonu)_