### PR TITLE
ci: add SPM cache, concurrency, permissions, path filters (refs #39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,21 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -38,6 +51,21 @@ jobs:
           # Skip macro fingerprint validation - required for Swift macros in CI
           defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
           defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
+
+      # `Package.resolved` is .gitignored, so we key on inputs that *do* land in
+      # the checkout: the Xcode project (which records remote package URLs and
+      # version pins) and any local `Package.swift` (GRDBCustom, NewsCombMCPBridge).
+      # Branch-tracking remote packages advance silently relative to this key —
+      # that's fine; the cache then goes stale and xcodebuild re-resolves.
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('NewsCombApp.xcodeproj/project.pbxproj', '**/Package.swift') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Install Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain


### PR DESCRIPTION
## Summary

Addresses items 3, 4, 5 and the path-filter nice-to-have from #39.

## Files changed

- `.github/workflows/ci.yml` — added top-level `concurrency` and `permissions` blocks, `paths-ignore` on `push` and `pull_request` triggers, and an SPM cache step ahead of the build.

## Item-by-item

- **3. SPM cache** — `actions/cache@v4` over `~/Library/Developer/Xcode/DerivedData/**/SourcePackages` and `~/Library/Caches/org.swift.swiftpm`. Cache key: `spm-macOS-<hash(NewsCombApp.xcodeproj/project.pbxproj, **/Package.swift)>`. Fallback `restore-keys` lets a stale cache restore even when the key changes, so the run still benefits from any partially-valid checkouts.
  - The issue suggested keying on `Package.resolved`, but that file is .gitignored — it gets generated at build time, so on a fresh CI checkout `hashFiles('**/Package.resolved')` would be the empty hash and every cache key would collapse to the same value.
  - The pbxproj captures URL/version-pin changes for `XCRemoteSwiftPackageReference` entries; the local `Package.swift` files capture changes to `GRDBCustom` and `NewsCombMCPBridge`.
  - Branch-tracking remote packages (e.g., `hypergraph-reasoning-swift` pinned to `branch = main`) advance silently relative to this key. Acceptable — when they advance, xcodebuild re-resolves and the cache is rebuilt on the next run.

- **4. `concurrency:` block** — `group: ci-${{ github.ref }}` with `cancel-in-progress: true`. Rapid pushes to the same PR (or main) supersede in-flight runs.

- **5. `permissions: contents: read`** — top-level read-only token. `release.yml` keeps its own job-scoped `contents: write` since it actually needs to upload release assets.

- **Nice-to-have: path filters** — `paths-ignore: ['**.md', 'docs/**']` on both `push` and `pull_request`. Doc-only changes skip CI.

## Out of scope

- **Item 6 (xcresult artifact upload on failure)** — defer to a follow-up.
- **Item 7 (pin or delete the unpinned `git clone` in `release.yml`)** — defer; the clone is also likely vestigial now that `hypergraph-reasoning-swift` is referenced via `XCRemoteSwiftPackageReference` in the project file. Worth its own audit.
- **Signing/notarization nice-to-have** — needs Apple Developer secrets in the repo first. Scaffolding remains commented in `release.yml`.
- **`-parallel-testing-enabled NO`** — issue says "only add if needed"; no evidence current tests need it.

## Caveat for branch protection

If `build` is configured as a required status check, doc-only PRs will produce no status (GitHub treats missing checks as missing, not pass). Not enabled today; flagging in case it changes.

## Test plan

- [ ] CI passes on this PR (validates that the new cache step doesn't break the existing build/test, and that paths-ignore doesn't accidentally suppress the run when ci.yml itself changes).
- [ ] Inspect post-merge run on main: confirm cache step says `Cache restored successfully` once we have a baseline run.

Refs #39