### PR TITLE
Folder import UI + pagination/search + graph filter modes

### DIFF
--- a/NewsCombApp/Services/FileImportService.swift
+++ b/NewsCombApp/Services/FileImportService.swift
@@ -1,0 +1,340 @@
+import Foundation
+import OSLog
+#if canImport(PDFKit)
+import PDFKit
+#endif
+
+private let logger = Logger(subsystem: "com.newscomb", category: "FileImportService")
+
+/// Service that walks a folder, extracts text from each supported file, and
+/// hands the results to `ArticleIngestionService` to insert into a freshly
+/// created manual feed. Mirrors the MCP `create_manual_feed` + `ingest_article`
+/// flow so UI imports are byte-for-byte indistinguishable from MCP imports.
+///
+/// The folder import primarily targets *codebase* ingestion (the user wants to
+/// load a project into NewsComb so the knowledge-graph extractor can mine
+/// cross-file relationships) but transparently handles plain text, Markdown,
+/// HTML, and PDF as well.
+struct FileImportService: Sendable {
+
+    /// Aggregated outcome reported back to the UI after a folder import.
+    struct Outcome: Sendable {
+        var sourceId: Int64
+        var sourceTitle: String
+        var ingested: Int = 0
+        var skippedTooShort: Int = 0
+        var skippedUnreadable: Int = 0
+        var skippedUnsupported: Int = 0
+        var skippedTooLarge: Int = 0
+        var totalCandidates: Int = 0
+    }
+
+    /// Per-file progress callback invoked on the main actor so the view model
+    /// can update observable state without crossing isolation boundaries.
+    typealias Progress = @MainActor @Sendable (_ processed: Int, _ total: Int, _ currentRelativePath: String) -> Void
+
+    /// Extensions whose contents we read verbatim as UTF-8 text. Covers the
+    /// common code formats the user listed (Swift, Java, Python, C/C++, TS/JS,
+    /// SQL, Go, Rust) plus generic text/markdown and structured data formats.
+    /// `.log` is deliberately excluded — log files are mostly machine-generated
+    /// noise (timestamps, stack traces) that would pollute the knowledge graph.
+    static let plainTextExtensions: Set<String> = [
+        "txt", "text", "md", "markdown", "rst",
+        "swift",
+        "java", "kt", "kts", "scala", "groovy",
+        "py", "rb", "php", "pl",
+        "c", "h", "cc", "cpp", "cxx", "hpp", "hh", "m", "mm",
+        "ts", "tsx", "js", "jsx", "mjs", "cjs",
+        "go", "rs",
+        "sql",
+        "yaml", "yml", "toml", "json", "ini", "cfg", "conf", "env",
+        "xml", "csv", "tsv",
+        "sh", "bash", "zsh", "fish",
+        "dockerfile", "makefile", "gradle"
+    ]
+    static let htmlExtensions: Set<String> = ["html", "htm", "xhtml"]
+    static let pdfExtensions: Set<String> = ["pdf"]
+
+    /// Directory names whose contents we never want to import — generated
+    /// build output, dependency caches, and virtualenvs that would balloon
+    /// the article count without adding signal. Compared lowercase against
+    /// `lastPathComponent` so APFS case-insensitivity (and the rare
+    /// case-sensitive volume) both work.
+    ///
+    /// Anything starting with `.` (e.g. `.build`, `.gradle`, `.idea`,
+    /// `.next`, `.venv`, `.tox`, `.pytest_cache`, `.mypy_cache`) is already
+    /// pruned by `.skipsHiddenFiles` on the enumerator, so it doesn't need
+    /// to appear here.
+    static let excludedDirectoryNames: Set<String> = [
+        // Generic / cross-language
+        "build",         // Xcode CLI, Gradle, CMake, generic
+        "dist",          // distribution / build output across many ecosystems
+        "out",           // IntelliJ default, Next.js
+        "coverage",      // test coverage report output
+
+        // Java / JVM
+        "target",        // Maven (and Rust Cargo — same name)
+        "bin",           // Eclipse-style compiled classes
+
+        // JavaScript / TypeScript
+        "node_modules",  // npm / yarn / pnpm dep tree
+
+        // Python
+        "__pycache__",   // bytecode cache
+        "venv",          // virtualenv (the non-hidden variant; `.venv` is hidden)
+
+        // Go (also PHP, Ruby)
+        "vendor"
+    ]
+
+    /// Skip files larger than this. 5 MB easily fits any source-code file but
+    /// drops vendored bundles or generated lockfiles dressed as `.json`.
+    static let maxFileSizeBytes: Int = 5 * 1024 * 1024
+
+    private let ingestionService: ArticleIngestionService
+
+    /// Test-friendly initializer: callers inject an `ArticleIngestionService`
+    /// bound to whatever `DatabaseQueue` they want (in-memory for unit tests).
+    init(ingestionService: ArticleIngestionService) {
+        self.ingestionService = ingestionService
+    }
+
+    /// Production initializer — binds to `ArticleIngestionService()` which in
+    /// turn binds to the active workspace's `Database.current`.
+    init() {
+        self.init(ingestionService: ArticleIngestionService())
+    }
+
+    /// Walks `rootURL` recursively, ingests every supported file as an article
+    /// inside a new manual feed titled `feedTitle`, and returns a summary.
+    ///
+    /// The whole walk runs off the main actor so a large codebase doesn't
+    /// stutter the UI; only the `progress` callback hops back onto `@MainActor`.
+    @concurrent
+    func importFolder(
+        rootURL: URL,
+        feedTitle: String,
+        progress: Progress? = nil
+    ) async throws -> Outcome {
+        let source = try ingestionService.createManualFeed(title: feedTitle)
+        guard let sourceId = source.id else {
+            // createManualFeed always returns a row with an id; this is
+            // belt-and-suspenders for the type system.
+            throw IngestionError.feedCreationReturnedNoId
+        }
+
+        var outcome = Outcome(sourceId: sourceId, sourceTitle: source.title ?? feedTitle)
+
+        let candidates = collectCandidates(at: rootURL)
+        outcome.totalCandidates = candidates.count
+
+        var processed = 0
+        for candidate in candidates {
+            try Task.checkCancellation()
+            processed += 1
+            let relativePath = candidate.relativePath
+
+            switch ingestSingle(candidate: candidate, sourceId: sourceId) {
+            case .ingested:
+                outcome.ingested += 1
+            case .skippedTooShort:
+                outcome.skippedTooShort += 1
+            case .skippedUnreadable:
+                outcome.skippedUnreadable += 1
+            case .skippedTooLarge:
+                outcome.skippedTooLarge += 1
+            }
+
+            if let progress {
+                let snapshot = (processed, candidates.count, relativePath)
+                await progress(snapshot.0, snapshot.1, snapshot.2)
+            }
+        }
+
+        logger.info("""
+            Folder import complete: ingested \(outcome.ingested, privacy: .public), \
+            skippedTooShort \(outcome.skippedTooShort, privacy: .public), \
+            skippedUnreadable \(outcome.skippedUnreadable, privacy: .public), \
+            skippedTooLarge \(outcome.skippedTooLarge, privacy: .public), \
+            unsupported \(outcome.skippedUnsupported, privacy: .public)
+        """)
+
+        return outcome
+    }
+
+    // MARK: - Internal helpers
+
+    enum IngestionError: Error, LocalizedError {
+        case feedCreationReturnedNoId
+
+        var errorDescription: String? {
+            switch self {
+            case .feedCreationReturnedNoId:
+                return "Manual feed was created but no row id was returned."
+            }
+        }
+    }
+
+    /// One file under the import root. We only enumerate supported extensions
+    /// up-front so the per-file step never has to consult the unsupported list.
+    struct Candidate {
+        var url: URL
+        var relativePath: String
+        var extensionLower: String
+        var fileSize: Int
+        var modificationDate: Date?
+    }
+
+    private enum SingleResult {
+        case ingested
+        case skippedTooShort
+        case skippedUnreadable
+        case skippedTooLarge
+    }
+
+    /// Enumerates `rootURL`, returning every regular file with a supported
+    /// extension. Hidden files and package descendants (`.xcodeproj`, `.app`)
+    /// are skipped via enumerator options. We collect the full candidate list
+    /// before ingesting so the progress callback can report a meaningful total.
+    private func collectCandidates(at rootURL: URL) -> [Candidate] {
+        let resourceKeys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .fileSizeKey,
+            .contentModificationDateKey
+        ]
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: Array(resourceKeys),
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return []
+        }
+
+        let rootPath = rootURL.standardizedFileURL.path
+        var out: [Candidate] = []
+
+        for case let url as URL in enumerator {
+            let standardized = url.standardizedFileURL
+
+            // Prune build-output subtrees before descending. `skipDescendants`
+            // is a no-op for regular files, so the unconditional check is
+            // safe — and a regular file literally named `build` (no
+            // extension) would also fail the supported-extension filter
+            // below, so we lose nothing by short-circuiting here.
+            if Self.excludedDirectoryNames.contains(standardized.lastPathComponent.lowercased()) {
+                enumerator.skipDescendants()
+                continue
+            }
+
+            guard let values = try? standardized.resourceValues(forKeys: resourceKeys),
+                  values.isRegularFile == true
+            else { continue }
+
+            let ext = standardized.pathExtension.lowercased()
+            guard isSupportedExtension(ext, filename: standardized.lastPathComponent) else { continue }
+
+            let fileSize = values.fileSize ?? 0
+            let relative = relativePath(of: standardized.path, under: rootPath)
+                ?? standardized.lastPathComponent
+
+            out.append(Candidate(
+                url: standardized,
+                relativePath: relative,
+                extensionLower: ext,
+                fileSize: fileSize,
+                modificationDate: values.contentModificationDate
+            ))
+        }
+
+        return out
+    }
+
+    /// Strips `rootPath` (plus its trailing slash) from `path`, or returns nil
+    /// when `path` doesn't sit under `rootPath` after standardization.
+    private func relativePath(of path: String, under rootPath: String) -> String? {
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        return String(path.dropFirst(prefix.count))
+    }
+
+    /// Some extensionless files (e.g. `Dockerfile`, `Makefile`) are still
+    /// readable as plain text; match them by exact filename in lowercase.
+    private func isSupportedExtension(_ ext: String, filename: String) -> Bool {
+        if Self.plainTextExtensions.contains(ext) { return true }
+        if Self.htmlExtensions.contains(ext) { return true }
+        if Self.pdfExtensions.contains(ext) { return true }
+        if ext.isEmpty {
+            let lowerName = filename.lowercased()
+            return Self.plainTextExtensions.contains(lowerName)
+        }
+        return false
+    }
+
+    /// Reads, extracts, and ingests one file. Returns which bucket the file
+    /// landed in so the caller can update the outcome counters.
+    private func ingestSingle(candidate: Candidate, sourceId: Int64) -> SingleResult {
+        if candidate.fileSize > Self.maxFileSizeBytes {
+            return .skippedTooLarge
+        }
+
+        let body: String?
+        if Self.plainTextExtensions.contains(candidate.extensionLower)
+            || (candidate.extensionLower.isEmpty
+                && Self.plainTextExtensions.contains(candidate.url.lastPathComponent.lowercased()))
+        {
+            body = readUTF8(candidate.url)
+        } else if Self.htmlExtensions.contains(candidate.extensionLower) {
+            body = readUTF8(candidate.url)?.strippingHTMLTags()
+        } else if Self.pdfExtensions.contains(candidate.extensionLower) {
+            body = readPDF(candidate.url)
+        } else {
+            // collectCandidates already filtered to supported extensions, so
+            // reaching here means a logic bug rather than user input we should
+            // tolerate silently — but treat as unreadable to avoid a crash.
+            return .skippedUnreadable
+        }
+
+        guard let body, !body.isEmpty else {
+            return .skippedUnreadable
+        }
+
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= ArticleIngestionService.minimumBodyLength else {
+            return .skippedTooShort
+        }
+
+        do {
+            _ = try ingestionService.ingestArticle(
+                sourceId: sourceId,
+                title: candidate.relativePath,
+                body: trimmed,
+                link: candidate.url.absoluteString,
+                author: nil,
+                pubDate: candidate.modificationDate,
+                guid: candidate.relativePath
+            )
+            return .ingested
+        } catch {
+            logger.error("Failed to ingest \(candidate.relativePath, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .skippedUnreadable
+        }
+    }
+
+    private func readUTF8(_ url: URL) -> String? {
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+
+    private func readPDF(_ url: URL) -> String? {
+        #if canImport(PDFKit)
+        guard let document = PDFDocument(url: url) else { return nil }
+        return document.string
+        #else
+        return nil
+        #endif
+    }
+}

--- a/NewsCombApp/Services/LongestPathFinder.swift
+++ b/NewsCombApp/Services/LongestPathFinder.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Finds the top-N longest simple paths in a graph using a bounded DFS heuristic.
+///
+/// Longest simple path is NP-hard in general graphs, so this is a heuristic:
+/// from each starting node, perform a depth-bounded DFS that tracks the
+/// longest non-repeating sequence of nodes reachable. The N globally longest
+/// candidates are returned (deduped by node-set membership).
+enum LongestPathFinder {
+
+    /// Compute the top `count` longest simple paths.
+    ///
+    /// - Parameters:
+    ///   - nodes: All nodes that may appear in a path.
+    ///   - edges: Edges defining adjacency. Edges are treated as undirected
+    ///     and hyperedges fully connect every source to every target.
+    ///   - count: Maximum number of paths to return (default 10).
+    ///   - maxDepth: Maximum simple-path length to consider, in nodes.
+    ///   - iterationBudget: Soft cap on total DFS recursive calls — protects
+    ///     against blow-up on dense graphs.
+    /// - Returns: Up to `count` paths, sorted longest-first. Each path is a
+    ///   sequence of node IDs.
+    static func topLongestPaths(
+        nodes: [GraphNode],
+        edges: [GraphEdge],
+        count: Int = 10,
+        maxDepth: Int = 15,
+        iterationBudget: Int = 200_000
+    ) -> [[Int64]] {
+        guard count > 0, !nodes.isEmpty, !edges.isEmpty else { return [] }
+
+        let adjacency = buildUndirectedAdjacency(edges: edges)
+        guard !adjacency.isEmpty else { return [] }
+
+        // Visit higher-degree nodes first — they are likelier to anchor
+        // long paths, and the iteration budget is more effective when
+        // promising starts run early.
+        let candidateIds: [Int64] = nodes.compactMap { node in
+            adjacency[node.id] != nil ? node.id : nil
+        }
+        let starts = candidateIds.sorted { lhs, rhs in
+            let l = adjacency[lhs]?.count ?? 0
+            let r = adjacency[rhs]?.count ?? 0
+            return l > r
+        }
+
+        var topPaths: [[Int64]] = []
+        var iterations = 0
+
+        for startId in starts {
+            if iterations >= iterationBudget { break }
+
+            var visited: Set<Int64> = [startId]
+            var currentPath: [Int64] = [startId]
+            var bestPath: [Int64] = [startId]
+
+            dfs(
+                current: startId,
+                adjacency: adjacency,
+                visited: &visited,
+                currentPath: &currentPath,
+                bestPath: &bestPath,
+                maxDepth: maxDepth,
+                iterations: &iterations,
+                iterationBudget: iterationBudget
+            )
+
+            if bestPath.count > 1 {
+                insertPath(bestPath, into: &topPaths, count: count)
+            }
+        }
+
+        return topPaths
+    }
+
+    /// Build undirected adjacency. Hyperedges fully connect each source-target
+    /// pair, mirroring how `GraphVisualizationView` draws them.
+    private static func buildUndirectedAdjacency(edges: [GraphEdge]) -> [Int64: Set<Int64>] {
+        var adjacency: [Int64: Set<Int64>] = [:]
+        for edge in edges {
+            for source in edge.sourceNodeIds {
+                for target in edge.targetNodeIds where source != target {
+                    adjacency[source, default: []].insert(target)
+                    adjacency[target, default: []].insert(source)
+                }
+            }
+        }
+        return adjacency
+    }
+
+    private static func dfs(
+        current: Int64,
+        adjacency: [Int64: Set<Int64>],
+        visited: inout Set<Int64>,
+        currentPath: inout [Int64],
+        bestPath: inout [Int64],
+        maxDepth: Int,
+        iterations: inout Int,
+        iterationBudget: Int
+    ) {
+        iterations += 1
+        if iterations > iterationBudget { return }
+
+        if currentPath.count > bestPath.count {
+            bestPath = currentPath
+        }
+
+        guard currentPath.count < maxDepth else { return }
+        guard let neighbors = adjacency[current] else { return }
+
+        for neighbor in neighbors where !visited.contains(neighbor) {
+            visited.insert(neighbor)
+            currentPath.append(neighbor)
+
+            dfs(
+                current: neighbor,
+                adjacency: adjacency,
+                visited: &visited,
+                currentPath: &currentPath,
+                bestPath: &bestPath,
+                maxDepth: maxDepth,
+                iterations: &iterations,
+                iterationBudget: iterationBudget
+            )
+
+            currentPath.removeLast()
+            visited.remove(neighbor)
+        }
+    }
+
+    /// Insert `path` into the top-N list, keeping it sorted descending by length
+    /// and rejecting candidates whose node-set duplicates an existing entry.
+    private static func insertPath(
+        _ path: [Int64],
+        into topPaths: inout [[Int64]],
+        count: Int
+    ) {
+        let pathSet = Set(path)
+        for existing in topPaths where Set(existing) == pathSet {
+            return
+        }
+
+        topPaths.append(path)
+        topPaths.sort { $0.count > $1.count }
+        if topPaths.count > count {
+            topPaths.removeLast()
+        }
+    }
+}

--- a/NewsCombApp/ViewModels/FeedItemsViewModel.swift
+++ b/NewsCombApp/ViewModels/FeedItemsViewModel.swift
@@ -39,52 +39,132 @@ struct FeedItemDisplay: Identifiable, Equatable, Hashable {
 @MainActor
 @Observable
 class FeedItemsViewModel {
+    /// Items loaded so far. Append-only across pages within one source filter;
+    /// reset on `loadInitial(...)` or when the source changes.
     var items: [FeedItemDisplay] = []
+    /// Populated by `performSearch()` when `searchText` is non-empty. Holds
+    /// SQL-matched rows from the *whole* table for the current source — not
+    /// the paginated subset. `nil` means no search is active and the view
+    /// should display `items`.
+    var searchResults: [FeedItemDisplay]?
+    /// True only while the very first page is being loaded; flipped off after
+    /// the initial fetch so the empty-state and "loading more" indicators can
+    /// show independently.
     var isLoading = false
+    /// True while a follow-up page is in flight. Drives the spinner row at the
+    /// bottom of the list.
+    var isLoadingMore = false
+    /// Becomes false once a fetch returns fewer than `pageSize` rows — at that
+    /// point we've reached the end of the table for the current filter and
+    /// further `loadMoreIfNeeded` calls are no-ops.
+    var hasMoreItems = true
     var errorMessage: String?
-    var selectedSourceId: Int64?
     var searchText: String = ""
+
+    /// True while a search query is in flight. Distinct from `isLoading`
+    /// (initial page) and `isLoadingMore` (next page) so the view can show a
+    /// search-specific affordance if needed.
+    var isSearching = false
+
+    /// Number of rows fetched per page. Small enough that the first page
+    /// renders quickly and the prefetch trigger fires while the user is still
+    /// scrolling, large enough that we don't re-query for every couple of rows.
+    static let pageSize = 50
+    /// When the user appears within this many rows of the bottom, we kick off
+    /// the next page. Tuned so the next batch is usually ready by the time
+    /// they reach it.
+    static let prefetchThreshold = 10
+
+    /// nil ⇒ "all articles" view (no source filter); non-nil ⇒ scoped to one
+    /// feed. Stored so `loadMoreIfNeeded`, `refresh`, and pagination math
+    /// don't have to be re-told the source on every call.
+    private(set) var currentSourceId: Int64?
 
     private let database = Database.current
 
+    /// What the view should render. `searchResults` takes precedence so a
+    /// search query reflects matches across the whole table; otherwise we
+    /// show the paginated `items`.
     var filteredItems: [FeedItemDisplay] {
-        var result = items
-
-        if selectedSourceId != nil {
-            // Source filtering is handled by loadItems(forSourceId:)
-            // This is a placeholder for future in-memory filtering
-        }
-
-        if !searchText.isEmpty {
-            result = result.filter { item in
-                item.title.localizedStandardContains(searchText) ||
-                item.snippet.localizedStandardContains(searchText) ||
-                item.sourceName.localizedStandardContains(searchText)
-            }
-        }
-
-        return result
+        searchResults ?? items
     }
 
-    func loadItems() {
-        isLoading = true
+    // MARK: - Public API
+
+    /// Reset pagination and load the first page. Call when entering the view
+    /// or switching sources. If `sourceId` matches the currently-loaded source
+    /// and we already have items, this is a no-op so navigating back to a feed
+    /// doesn't re-issue a query and lose scroll position.
+    func loadInitial(forSourceId sourceId: Int64?) {
+        if currentSourceId == sourceId, !items.isEmpty {
+            return
+        }
+        currentSourceId = sourceId
+        items = []
+        searchResults = nil  // a different source's results would be misleading
+        hasMoreItems = true
         errorMessage = nil
+        loadNextPage(initial: true)
+    }
+
+    /// Trigger another page if `currentItem` is within the prefetch window
+    /// from the bottom of the loaded list and we haven't yet exhausted the
+    /// table. Safe to call from a `.onAppear` on every row — the guards below
+    /// keep duplicate fetches from overlapping.
+    func loadMoreIfNeeded(currentItem: FeedItemDisplay) {
+        guard hasMoreItems, !isLoadingMore, !isLoading else { return }
+        guard let index = items.firstIndex(where: { $0.id == currentItem.id }) else { return }
+        let triggerIndex = items.count - Self.prefetchThreshold
+        if index >= max(0, triggerIndex) {
+            loadNextPage(initial: false)
+        }
+    }
+
+    /// Run a substring search across the whole `feed_item` table for the
+    /// current source. When `searchText` is empty, drops `searchResults` so
+    /// the view falls back to the paginated `items`.
+    ///
+    /// Uses SQL `LIKE` (not FTS5) — there's no `feed_item_fts` virtual table
+    /// in this schema, and adding one is heavier scope than warranted at
+    /// today's row counts. `LIKE` is case-insensitive for ASCII (its default
+    /// in SQLite) and fast enough on a few-thousand-row `feed_item` table.
+    /// `%`, `_`, and `\` in the user input are escaped so they don't smuggle
+    /// in wildcards.
+    func performSearch() {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            searchResults = nil
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+        defer { isSearching = false }
+
+        let pattern = "%" + escapeForLike(trimmed) + "%"
+        let sourceId = currentSourceId
 
         do {
-            let fetchedItems: [(FeedItem, RSSSource?)] = try database.read { db in
-                let request = FeedItem
-                    .order(FeedItem.Columns.pubDate.desc, FeedItem.Columns.fetchedAt.desc)
-                    .limit(100)
+            let fetched: [(FeedItem, RSSSource?)] = try database.read { db in
+                var sql = """
+                    SELECT * FROM feed_item
+                    WHERE (title LIKE ? ESCAPE '\\' OR full_content LIKE ? ESCAPE '\\')
+                    """
+                var args: [(any DatabaseValueConvertible)?] = [pattern, pattern]
+                if let sourceId {
+                    sql += " AND source_id = ?"
+                    args.append(sourceId)
+                }
+                sql += " ORDER BY pub_date DESC, fetched_at DESC LIMIT 500"
 
-                let items = try request.fetchAll(db)
-
-                return try items.map { item in
+                let rows = try FeedItem.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                return try rows.map { item in
                     let source = try RSSSource.filter(RSSSource.Columns.id == item.sourceId).fetchOne(db)
                     return (item, source)
                 }
             }
 
-            items = fetchedItems.compactMap { item, source in
+            searchResults = fetched.compactMap { item, source -> FeedItemDisplay? in
                 guard let id = item.id else { return nil }
                 return FeedItemDisplay(
                     id: id,
@@ -99,53 +179,110 @@ class FeedItemsViewModel {
                 )
             }
         } catch {
-            errorMessage = "Failed to load items: \(error.localizedDescription)"
+            errorMessage = "Search failed: \(error.localizedDescription)"
+            searchResults = []
         }
-
-        isLoading = false
     }
 
-    func loadItems(forSourceId sourceId: Int64) {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            let fetchedItems: [(FeedItem, RSSSource?)] = try database.read { db in
-                let request = FeedItem
-                    .filter(FeedItem.Columns.sourceId == sourceId)
-                    .order(FeedItem.Columns.pubDate.desc, FeedItem.Columns.fetchedAt.desc)
-                    .limit(100)
-
-                let items = try request.fetchAll(db)
-
-                return try items.map { item in
-                    let source = try RSSSource.filter(RSSSource.Columns.id == item.sourceId).fetchOne(db)
-                    return (item, source)
-                }
+    /// Escapes the three SQLite `LIKE` wildcards so a user typing `100%` or
+    /// `foo_bar` searches for those literal substrings rather than triggering
+    /// pattern matching. Mirrors the `ESCAPE '\'` clause used in the query.
+    private func escapeForLike(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            switch ch {
+            case "\\", "%", "_": out.append("\\")
+            default: break
             }
-
-            items = fetchedItems.compactMap { item, source in
-                guard let id = item.id else { return nil }
-                return FeedItemDisplay(
-                    id: id,
-                    title: item.title,
-                    sourceName: source?.title ?? source?.url ?? "Unknown",
-                    link: item.link,
-                    pubDate: item.pubDate,
-                    rssDescription: item.rssDescription,
-                    fullContent: item.fullContent,
-                    author: item.author,
-                    isRead: false
-                )
-            }
-        } catch {
-            errorMessage = "Failed to load items: \(error.localizedDescription)"
+            out.append(ch)
         }
-
-        isLoading = false
+        return out
     }
 
+    /// Pull-to-refresh: reset pagination and reload the first page from the
+    /// current source.
     func refresh() async {
-        loadItems()
+        let source = currentSourceId
+        currentSourceId = nil  // force loadInitial to re-fetch even if items were stale
+        loadInitial(forSourceId: source)
+    }
+
+    // MARK: - Back-compat shims
+
+    /// Legacy entry point — kept so any caller still using the old API loads
+    /// data correctly. Routes through the paginated flow.
+    func loadItems() {
+        loadInitial(forSourceId: nil)
+    }
+
+    /// Legacy entry point — kept for back-compat with `FeedItemsView.onAppear`.
+    func loadItems(forSourceId sourceId: Int64) {
+        loadInitial(forSourceId: sourceId)
+    }
+
+    // MARK: - Internals
+
+    private func loadNextPage(initial: Bool) {
+        if initial {
+            isLoading = true
+        } else {
+            isLoadingMore = true
+        }
+        defer {
+            isLoading = false
+            isLoadingMore = false
+        }
+
+        let offset = items.count
+        let limit = Self.pageSize
+        let sourceId = currentSourceId
+
+        do {
+            let fetched: [(FeedItem, RSSSource?)] = try database.read { db in
+                var request = FeedItem
+                    .order(FeedItem.Columns.pubDate.desc, FeedItem.Columns.fetchedAt.desc)
+                    .limit(limit, offset: offset)
+                if let sourceId {
+                    request = FeedItem
+                        .filter(FeedItem.Columns.sourceId == sourceId)
+                        .order(FeedItem.Columns.pubDate.desc, FeedItem.Columns.fetchedAt.desc)
+                        .limit(limit, offset: offset)
+                }
+
+                let rows = try request.fetchAll(db)
+                return try rows.map { item in
+                    let source = try RSSSource.filter(RSSSource.Columns.id == item.sourceId).fetchOne(db)
+                    return (item, source)
+                }
+            }
+
+            let newItems = fetched.compactMap { item, source -> FeedItemDisplay? in
+                guard let id = item.id else { return nil }
+                return FeedItemDisplay(
+                    id: id,
+                    title: item.title,
+                    sourceName: source?.title ?? source?.url ?? "Unknown",
+                    link: item.link,
+                    pubDate: item.pubDate,
+                    rssDescription: item.rssDescription,
+                    fullContent: item.fullContent,
+                    author: item.author,
+                    isRead: false
+                )
+            }
+
+            items.append(contentsOf: newItems)
+            // A short page means we've drained the table for this filter.
+            // Use the raw fetch count, not newItems.count, so a row whose
+            // `id` is nil (impossible in practice but defended against above)
+            // doesn't incorrectly extend pagination.
+            if fetched.count < limit {
+                hasMoreItems = false
+            }
+        } catch {
+            errorMessage = "Failed to load items: \(error.localizedDescription)"
+            hasMoreItems = false  // bail out of paging on error to avoid retry loops
+        }
     }
 }

--- a/NewsCombApp/ViewModels/GraphViewModel.swift
+++ b/NewsCombApp/ViewModels/GraphViewModel.swift
@@ -41,6 +41,7 @@ class GraphViewModel {
         didSet {
             if connectionThreshold != oldValue {
                 expandedNodeIds.removeAll()
+            showingMatchesOnly = false
             }
         }
     }
@@ -53,6 +54,57 @@ class GraphViewModel {
 
     /// Custom node color hex value
     var nodeColorHex: String = AppSettings.defaultGraphNodeColor
+
+    /// When true, `visibleNodes` is restricted to nodes that participate in
+    /// the top-N longest paths instead of the connection-threshold filter.
+    var showingLongestPathsOnly = false
+
+    /// Set of node IDs that appear in the top longest paths (populated when
+    /// `showingLongestPathsOnly` is enabled).
+    var longestPathNodeIds: Set<Int64> = []
+
+    /// When true, `visibleNodes` is restricted to search-matched nodes plus
+    /// any node the user has expanded via double-click. Useful for drilling
+    /// into a search result without surrounding clutter.
+    var showingMatchesOnly = false
+
+    /// How many longest paths to show when the filter is active.
+    static let longestPathsCount = 10
+
+    /// Cached top-N longest paths over the current graph. Invalidated when
+    /// graph topology changes. Stored as `@ObservationIgnored` so reads
+    /// during view rendering can populate it without observation churn.
+    @ObservationIgnored
+    private var cachedLongestPaths: [[Int64]]?
+
+    /// Length (in nodes) of the single longest path in the current graph.
+    /// Returns 0 if the graph has no edges or no path could be found.
+    var longestPathLength: Int {
+        longestPaths().first?.count ?? 0
+    }
+
+    /// Compute (or return cached) top-N longest paths over the current graph.
+    func longestPaths() -> [[Int64]] {
+        if let cached = cachedLongestPaths { return cached }
+
+        let paths = LongestPathFinder.topLongestPaths(
+            nodes: nodes,
+            edges: edges,
+            count: Self.longestPathsCount
+        )
+        cachedLongestPaths = paths
+        return paths
+    }
+
+    /// Invalidate the longest-paths cache. Call after any topology change.
+    private func invalidateLongestPathsCache() {
+        cachedLongestPaths = nil
+        // Reset the filter too: cached node IDs are stale.
+        if showingLongestPathsOnly {
+            showingLongestPathsOnly = false
+            longestPathNodeIds = []
+        }
+    }
 
     // MARK: - Search State
 
@@ -134,9 +186,47 @@ class GraphViewModel {
 
     // MARK: - Computed Properties
 
-    /// Nodes visible after applying threshold filter and expansions
+    /// Nodes visible after applying the active filter mode.
+    ///
+    /// Three modes, mutually exclusive:
+    /// - **Matches only** (`showingMatchesOnly`): search hits ∪ expanded.
+    /// - **Longest paths** (`showingLongestPathsOnly`): nodes on the top-N
+    ///   longest paths.
+    /// - **Threshold** (default): degree ≥ threshold ∪ expanded.
     var visibleNodes: [GraphNode] {
-        nodes.filter { $0.degree >= connectionThreshold || expandedNodeIds.contains($0.id) }
+        Self.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: showingMatchesOnly,
+            showingLongestPathsOnly: showingLongestPathsOnly,
+            matchedNodeIds: matchedNodeIds,
+            expandedNodeIds: expandedNodeIds,
+            longestPathNodeIds: longestPathNodeIds,
+            connectionThreshold: connectionThreshold
+        )
+    }
+
+    /// Pure filter logic, exposed for unit testing without instantiating the
+    /// view model (which would touch `Database.current`).
+    nonisolated static func filterVisibleNodes(
+        _ nodes: [GraphNode],
+        showingMatchesOnly: Bool,
+        showingLongestPathsOnly: Bool,
+        matchedNodeIds: Set<Int64>,
+        expandedNodeIds: Set<Int64>,
+        longestPathNodeIds: Set<Int64>,
+        connectionThreshold: Int
+    ) -> [GraphNode] {
+        if showingMatchesOnly {
+            return nodes.filter {
+                matchedNodeIds.contains($0.id) || expandedNodeIds.contains($0.id)
+            }
+        }
+        if showingLongestPathsOnly {
+            return nodes.filter { longestPathNodeIds.contains($0.id) }
+        }
+        return nodes.filter {
+            $0.degree >= connectionThreshold || expandedNodeIds.contains($0.id)
+        }
     }
 
     /// Set of visible node IDs for efficient lookups
@@ -165,6 +255,7 @@ class GraphViewModel {
     func loadGraph() {
         isLoading = true
         errorMessage = nil
+        invalidateLongestPathsCache()
 
         do {
             let data = try graphDataService.loadFullGraph()
@@ -172,6 +263,7 @@ class GraphViewModel {
             edges = data.edges
             maxDegree = max(data.maxDegree, 1)
             expandedNodeIds.removeAll()
+            showingMatchesOnly = false
 
             // Calculate optimal threshold to show ~50 nodes
             connectionThreshold = calculateOptimalThreshold(targetCount: 50)
@@ -221,6 +313,7 @@ class GraphViewModel {
         isLoading = true
         errorMessage = nil
         focusedNodeId = nodeId
+        invalidateLongestPathsCache()
 
         do {
             let data = try graphDataService.loadNeighborhood(nodeId: nodeId)
@@ -228,6 +321,7 @@ class GraphViewModel {
             edges = data.edges
             maxDegree = max(data.maxDegree, 1)
             expandedNodeIds.removeAll()
+            showingMatchesOnly = false
 
             rebuildNodeIndex()
 
@@ -492,6 +586,98 @@ class GraphViewModel {
         updateNodePositionsFromLayout()
     }
 
+    // MARK: - Longest Paths Filter
+
+    /// Toggle the "show only top-N longest paths" filter.
+    ///
+    /// When enabling, computes the longest paths over the currently loaded
+    /// graph and stores the union of nodes that participate in them.
+    /// When disabling, clears the cached node set so the regular threshold
+    /// filter takes over again.
+    func toggleLongestPaths() {
+        if showingLongestPathsOnly {
+            showingLongestPathsOnly = false
+            longestPathNodeIds = []
+            return
+        }
+
+        let paths = longestPaths()
+        let pathNodeIds = Set(paths.flatMap { $0 })
+
+        guard !pathNodeIds.isEmpty else {
+            errorMessage = "Could not find any paths in the current graph."
+            return
+        }
+
+        // Mutually exclusive with the matches-only filter.
+        showingMatchesOnly = false
+        longestPathNodeIds = pathNodeIds
+        showingLongestPathsOnly = true
+    }
+
+    // MARK: - Focus on Search Match
+
+    /// Bring a search-result node into the visible graph and switch to the
+    /// matches-only filter so the user sees a small, connected island
+    /// centered on what they just clicked — not every search hit at once.
+    ///
+    /// Steps:
+    /// 1. Narrow `matchedNodeIds` to just this row, so only the clicked
+    ///    node is drawn yellow (the rest of the FTS hits stop dominating
+    ///    the canvas).
+    /// 2. Expand the node (loads its 1-hop neighbors into `expandedNodeIds`,
+    ///    which `filterVisibleNodes` unions with `matchedNodeIds`).
+    /// 3. Activate `showingMatchesOnly` (mutually exclusive with longest paths).
+    /// 4. Center the view on the matched node.
+    ///
+    /// The full `searchResults` panel data is preserved so the user can
+    /// click another row to pivot focus.
+    ///
+    /// `expandNode` is a no-op when the node isn't currently in `nodes`
+    /// (e.g., focused-view searches that match outside the loaded
+    /// neighborhood). The matched node itself stays visible through
+    /// `matchedNodeIds` regardless.
+    func focusOnSearchMatch(nodeId: Int64) {
+        matchedNodeIds = [nodeId]
+        expandNode(nodeId)
+
+        if showingLongestPathsOnly {
+            showingLongestPathsOnly = false
+            longestPathNodeIds = []
+        }
+        showingMatchesOnly = true
+
+        centerOnNode(nodeId)
+    }
+
+    // MARK: - Matches-Only Filter
+
+    /// Toggle the "show only search matches and expanded neighbors" filter.
+    ///
+    /// When enabled, `visibleNodes` is restricted to the union of
+    /// `matchedNodeIds` (search hits, drawn yellow) and `expandedNodeIds`
+    /// (nodes the user has revealed via double-click). Designed for the flow:
+    /// *search → see the yellow matches → double-click one to expand its
+    /// neighbors → keep drilling without other clutter on screen.*
+    func toggleMatchesOnly() {
+        if showingMatchesOnly {
+            showingMatchesOnly = false
+            return
+        }
+
+        guard !matchedNodeIds.isEmpty || !expandedNodeIds.isEmpty else {
+            errorMessage = "No search matches yet. Search for a node or edge first, then enable this filter."
+            return
+        }
+
+        // Mutually exclusive with the longest-paths filter.
+        if showingLongestPathsOnly {
+            showingLongestPathsOnly = false
+            longestPathNodeIds = []
+        }
+        showingMatchesOnly = true
+    }
+
     // MARK: - Node Color Settings
 
     /// Load the node color setting from the database.
@@ -564,6 +750,7 @@ class GraphViewModel {
 
             // Merge new data into the graph
             if !addedNodes.isEmpty {
+                invalidateLongestPathsCache()
                 nodes.append(contentsOf: addedNodes)
 
                 let existingEdgeIds = Set(edges.map(\.id))

--- a/NewsCombApp/ViewModels/MainViewModel.swift
+++ b/NewsCombApp/ViewModels/MainViewModel.swift
@@ -44,6 +44,12 @@ class MainViewModel {
     var opmlImportResult: OPMLImportResult?
     var opmlURLInput: String = ""
 
+    // Local-file (folder) import state
+    var isImportingFiles = false
+    var fileImportProgress: (processed: Int, total: Int) = (0, 0)
+    var currentImportingFile: String = ""
+    var fileImportResult: FileImportService.Outcome?
+
     // Feed statistics
     var newArticlesFromLastRefresh: Int = 0
     var lastRefreshTime: Date?
@@ -87,6 +93,9 @@ class MainViewModel {
 
     @ObservationIgnored
     private let nodeMergingService = NodeMergingService()
+
+    @ObservationIgnored
+    private let fileImportService = FileImportService()
 
     // MARK: - Computed Statistics
 
@@ -162,6 +171,40 @@ class MainViewModel {
             applyOPMLFeeds(feeds)
         } catch {
             errorMessage = "Failed to import OPML: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Local file (folder) import
+
+    /// Recursively imports every supported file under `rootURL` as articles in
+    /// a fresh manual feed. Mirrors the MCP `create_manual_feed` +
+    /// `ingest_article` tools so the feed appears identical to one created
+    /// from an MCP client. Knowledge-graph processing is *not* triggered
+    /// automatically — the user clicks "Process Knowledge Graph" afterward.
+    func importFolder(rootURL: URL, feedTitle: String) async {
+        guard !isImportingFiles else { return }
+        isImportingFiles = true
+        fileImportProgress = (0, 0)
+        currentImportingFile = ""
+        defer {
+            isImportingFiles = false
+            currentImportingFile = ""
+        }
+
+        do {
+            let outcome = try await fileImportService.importFolder(
+                rootURL: rootURL,
+                feedTitle: feedTitle
+            ) { @MainActor [weak self] processed, total, current in
+                self?.fileImportProgress = (processed, total)
+                self?.currentImportingFile = current
+            }
+            fileImportResult = outcome
+            loadSources()
+        } catch is CancellationError {
+            // User cancelled; not an error worth surfacing.
+        } catch {
+            errorMessage = "Folder import failed: \(error.localizedDescription)"
         }
     }
 

--- a/NewsCombApp/Views/FeedItemsView.swift
+++ b/NewsCombApp/Views/FeedItemsView.swift
@@ -37,6 +37,29 @@ struct FeedItemsView: View {
                         }
                     }
                 }
+                // Prefetch the next page when the user scrolls within
+                // `prefetchThreshold` rows of the bottom. Search is in-memory
+                // so we drive prefetch off the unfiltered `items` indices —
+                // skip prefetch while a search is active to avoid pulling in
+                // more rows the user can't see anyway.
+                .onAppear {
+                    if viewModel.searchText.isEmpty {
+                        viewModel.loadMoreIfNeeded(currentItem: item)
+                    }
+                }
+            }
+
+            if viewModel.isLoadingMore {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading more…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .listRowSeparator(.hidden)
             }
         }
         .navigationTitle(sourceName ?? "All Articles")
@@ -76,11 +99,14 @@ struct FeedItemsView: View {
             }
         }
         .onAppear {
-            if let sourceId {
-                viewModel.loadItems(forSourceId: sourceId)
-            } else {
-                viewModel.loadItems()
-            }
+            viewModel.loadInitial(forSourceId: sourceId)
+        }
+        // SwiftUI delivers `searchText` updates as the user types. Each
+        // change triggers a fresh SQL query — fast on the few-hundred-row
+        // tables this app sees, and the prefetch trigger is gated by
+        // `searchText.isEmpty` so we don't paginate during search.
+        .onChange(of: viewModel.searchText) { _, _ in
+            viewModel.performSearch()
         }
         .alert("Error", isPresented: .init(
             get: { viewModel.errorMessage != nil },

--- a/NewsCombApp/Views/FolderImportFlowModifier.swift
+++ b/NewsCombApp/Views/FolderImportFlowModifier.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Bundles the three modifiers that drive the local-folder import flow:
+/// the `.fileImporter` for picking a folder, the title-confirmation sheet,
+/// and the result alert. Extracted into a `ViewModifier` so MainView's body
+/// modifier chain stays under the SwiftUI type-checker's complexity budget.
+struct FolderImportFlowModifier: ViewModifier {
+    @Bindable var viewModel: MainViewModel
+    @Binding var showingFolderPicker: Bool
+    @Binding var showingImportTitleSheet: Bool
+    @Binding var pendingImportFolder: URL?
+    @Binding var importFeedTitle: String
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporter(
+                isPresented: $showingFolderPicker,
+                allowedContentTypes: [.folder]
+            ) { result in
+                switch result {
+                case .success(let url):
+                    pendingImportFolder = url
+                    importFeedTitle = url.lastPathComponent
+                    showingImportTitleSheet = true
+                case .failure(let error):
+                    viewModel.errorMessage = "Failed to open folder: \(error.localizedDescription)"
+                }
+            }
+            .sheet(isPresented: $showingImportTitleSheet) {
+                FolderImportTitleSheet(
+                    folderURL: pendingImportFolder,
+                    title: $importFeedTitle,
+                    onConfirm: confirmImport,
+                    onCancel: cancelImport
+                )
+            }
+            .alert("Import Complete", isPresented: importResultBinding) {
+                Button("OK") { viewModel.fileImportResult = nil }
+            } message: {
+                if let r = viewModel.fileImportResult {
+                    Text(Self.resultMessage(r))
+                }
+            }
+    }
+
+    private var importResultBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.fileImportResult != nil },
+            set: { if !$0 { viewModel.fileImportResult = nil } }
+        )
+    }
+
+    private func confirmImport() {
+        guard let url = pendingImportFolder else { return }
+        let title = importFeedTitle
+        showingImportTitleSheet = false
+        Task {
+            // Security-scoped access must wrap the entire recursive import —
+            // every per-file read inside the enumerator inherits the parent
+            // folder's scope on macOS sandboxed builds.
+            let gotAccess = url.startAccessingSecurityScopedResource()
+            defer { if gotAccess { url.stopAccessingSecurityScopedResource() } }
+            await viewModel.importFolder(rootURL: url, feedTitle: title)
+        }
+    }
+
+    private func cancelImport() {
+        showingImportTitleSheet = false
+        pendingImportFolder = nil
+    }
+
+    static func resultMessage(_ r: FileImportService.Outcome) -> String {
+        var parts: [String] = []
+        parts.append("Ingested \(r.ingested) file\(r.ingested == 1 ? "" : "s") into \"\(r.sourceTitle)\".")
+        var skips: [String] = []
+        if r.skippedTooShort > 0 { skips.append("\(r.skippedTooShort) too short") }
+        if r.skippedUnreadable > 0 { skips.append("\(r.skippedUnreadable) unreadable") }
+        if r.skippedTooLarge > 0 { skips.append("\(r.skippedTooLarge) too large") }
+        if !skips.isEmpty {
+            parts.append("Skipped: " + skips.joined(separator: ", ") + ".")
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/NewsCombApp/Views/FolderImportTitleSheet.swift
+++ b/NewsCombApp/Views/FolderImportTitleSheet.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Lightweight sheet that appears after the user picks a folder for local
+/// import. Lets the user confirm or rename the manual feed title before the
+/// (potentially long) recursive import runs. The sheet is purely presentational
+/// — it doesn't touch the database; the parent view's `onConfirm` callback
+/// drives `MainViewModel.importFolder`.
+struct FolderImportTitleSheet: View {
+    let folderURL: URL?
+    @Binding var title: String
+    var onConfirm: () -> Void
+    var onCancel: () -> Void
+
+    @FocusState private var titleFieldFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Feed title", text: $title)
+                        .focused($titleFieldFocused)
+                        #if os(iOS)
+                        .textInputAutocapitalization(.words)
+                        #endif
+                } header: {
+                    Text("Feed title")
+                } footer: {
+                    Text("This will appear in the sources list. The folder's files are imported as articles inside this feed.")
+                }
+
+                if let folderURL {
+                    Section {
+                        LabeledContent("Folder") {
+                            Text(folderURL.path)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                                .truncationMode(.middle)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Import Local Files")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Import", action: onConfirm)
+                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .onAppear { titleFieldFocused = true }
+        }
+        .frame(minWidth: 420, minHeight: 220)
+    }
+}

--- a/NewsCombApp/Views/GraphSearchOverlay.swift
+++ b/NewsCombApp/Views/GraphSearchOverlay.swift
@@ -113,7 +113,11 @@ struct GraphSearchOverlay: View {
 
             ForEach(matches) { match in
                 NodeMatchRow(match: match) {
-                    viewModel.loadNodeProvenance(nodeId: match.id)
+                    // Previously opened the source-article provenance sheet:
+                    // viewModel.loadNodeProvenance(nodeId: match.id)
+                    // Now: bring the node + its 1-hop neighbors into the
+                    // graph, mark them yellow, switch to matches-only view.
+                    viewModel.focusOnSearchMatch(nodeId: match.id)
                 }
             }
         }

--- a/NewsCombApp/Views/GraphVisualizationView.swift
+++ b/NewsCombApp/Views/GraphVisualizationView.swift
@@ -766,6 +766,34 @@ struct GraphVisualizationView: View {
                 }
                 .help("Reload graph data")
 
+                Button(
+                    viewModel.showingLongestPathsOnly ? "All Nodes" : "Top 10 Paths",
+                    systemImage: viewModel.showingLongestPathsOnly
+                        ? "circle.grid.3x3"
+                        : "point.3.connected.trianglepath.dotted"
+                ) {
+                    viewModel.toggleLongestPaths()
+                }
+                .help(
+                    viewModel.showingLongestPathsOnly
+                        ? "Show all nodes again"
+                        : "Show only the top 10 longest paths"
+                )
+
+                Button(
+                    viewModel.showingMatchesOnly ? "Show All" : "Matches Only",
+                    systemImage: viewModel.showingMatchesOnly
+                        ? "line.3.horizontal.decrease.circle.fill"
+                        : "line.3.horizontal.decrease.circle"
+                ) {
+                    viewModel.toggleMatchesOnly()
+                }
+                .help(
+                    viewModel.showingMatchesOnly
+                        ? "Show all nodes again"
+                        : "Show only search matches and any nodes you've expanded from them"
+                )
+
                 Divider()
                     .frame(height: 20)
 
@@ -845,6 +873,7 @@ struct GraphVisualizationView: View {
                 StatRow(label: "Avg connections", value: String(format: "%.1f", averageDegree))
                 StatRow(label: "Isolated nodes", value: "\(isolatedNodeCount)")
                 StatRow(label: "Density", value: String(format: "%.2f%%", graphDensity * 100))
+                StatRow(label: "Longest path", value: "\(viewModel.longestPathLength) nodes")
             }
 
             // Top connected nodes

--- a/NewsCombApp/Views/MainView.swift
+++ b/NewsCombApp/Views/MainView.swift
@@ -14,6 +14,10 @@ struct MainView: View {
     @State private var exportSuccess: String?
     @State private var showingOPMLFilePicker = false
     @State private var showingOPMLURLInput = false
+    @State private var showingFolderPicker = false
+    @State private var pendingImportFolder: URL?
+    @State private var importFeedTitle: String = ""
+    @State private var showingImportTitleSheet = false
     @Environment(\.scenePhase) private var scenePhase
     #if os(macOS)
     @Environment(\.openWindow) private var openWindow
@@ -234,6 +238,13 @@ struct MainView: View {
                     Text("Added \(result.added) new feed\(result.added == 1 ? "" : "s"). \(result.skipped) already existed.")
                 }
             }
+            .modifier(FolderImportFlowModifier(
+                viewModel: viewModel,
+                showingFolderPicker: $showingFolderPicker,
+                showingImportTitleSheet: $showingImportTitleSheet,
+                pendingImportFolder: $pendingImportFolder,
+                importFeedTitle: $importFeedTitle
+            ))
         }
     }
 
@@ -658,10 +669,33 @@ struct MainView: View {
                 }
             }
             .disabled(viewModel.isImportingOPML)
+
+            Menu {
+                Button("From Folder...", systemImage: "folder.badge.plus") {
+                    showingFolderPicker = true
+                }
+            } label: {
+                if viewModel.isImportingFiles {
+                    Label {
+                        let p = viewModel.fileImportProgress
+                        if p.total > 0 {
+                            Text("Importing files \(p.processed)/\(p.total)...")
+                        } else {
+                            Text("Scanning folder...")
+                        }
+                    } icon: {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                } else {
+                    Label("Import Local Files", systemImage: "doc.badge.plus")
+                }
+            }
+            .disabled(viewModel.isImportingFiles)
         } header: {
             Text("Add RSS Feed")
         } footer: {
-            Text("Add RSS feed URLs individually, paste multiple URLs, or import from an OPML file.")
+            Text("Add RSS feed URLs individually, paste multiple URLs, import from an OPML file, or import a folder of local files (codebases, notes, PDFs) as articles.")
         }
     }
 

--- a/NewsCombAppTests/FeedItemsViewModelPaginationTests.swift
+++ b/NewsCombAppTests/FeedItemsViewModelPaginationTests.swift
@@ -1,0 +1,317 @@
+import XCTest
+import GRDB
+@testable import NewsCombApp
+
+/// Pagination tests for `FeedItemsViewModel`. Subclasses
+/// `IsolatedDatabaseTestCase` so each test gets a fresh `Database.current`,
+/// matching the project pattern used by services that capture
+/// `Database.current` at init time.
+@MainActor
+final class FeedItemsViewModelPaginationTests: IsolatedDatabaseTestCase {
+
+    /// Seed `count` feed items with monotonically descending pubDates so the
+    /// `pubDate DESC` ordering used by the view model produces a deterministic
+    /// sequence. Returns the inserted source id.
+    private func seedFeed(count: Int) throws -> Int64 {
+        return try database.write { db -> Int64 in
+            try db.execute(
+                sql: "INSERT INTO rss_source (url, title) VALUES (?, ?)",
+                arguments: ["manual:feed:test-\(UUID().uuidString)", "Test Feed"]
+            )
+            let sourceId = db.lastInsertedRowID
+
+            for i in 0..<count {
+                let pubDate = Double(2_000_000_000 - i)  // newer first when i is small
+                try db.execute(
+                    sql: """
+                        INSERT INTO feed_item (source_id, guid, title, link, pub_date, full_content)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        sourceId,
+                        "guid-\(i)",
+                        "Item \(String(format: "%04d", i))",
+                        "manual:item:\(i)",
+                        pubDate,
+                        String(repeating: "x", count: 200)
+                    ]
+                )
+            }
+            return sourceId
+        }
+    }
+
+    // MARK: - Initial page
+
+    func testInitialPageLoadsExactlyPageSize() throws {
+        let sourceId = try seedFeed(count: FeedItemsViewModel.pageSize * 3)
+        let vm = FeedItemsViewModel()
+
+        vm.loadInitial(forSourceId: sourceId)
+
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize)
+        XCTAssertTrue(vm.hasMoreItems)
+        XCTAssertFalse(vm.isLoading)
+        // Newest items first (smallest i first because of descending pub_date)
+        XCTAssertEqual(vm.items.first?.title, "Item 0000")
+    }
+
+    func testInitialPageHandlesShortFeedAndExhausts() throws {
+        let total = FeedItemsViewModel.pageSize - 5
+        let sourceId = try seedFeed(count: total)
+        let vm = FeedItemsViewModel()
+
+        vm.loadInitial(forSourceId: sourceId)
+
+        XCTAssertEqual(vm.items.count, total)
+        XCTAssertFalse(vm.hasMoreItems, "Page returning fewer than pageSize must mark exhaustion")
+    }
+
+    // MARK: - Pagination
+
+    func testLoadMoreIfNeededAppendsNextPage() throws {
+        let sourceId = try seedFeed(count: FeedItemsViewModel.pageSize * 3)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+
+        // The "current item" is the last loaded — definitely within the
+        // prefetch threshold from the bottom.
+        let lastVisible = vm.items.last!
+        vm.loadMoreIfNeeded(currentItem: lastVisible)
+
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize * 2)
+        XCTAssertTrue(vm.hasMoreItems)
+        XCTAssertEqual(vm.items.first?.title, "Item 0000", "First page must remain stable")
+        XCTAssertEqual(vm.items.last?.title, String(format: "Item %04d", FeedItemsViewModel.pageSize * 2 - 1))
+    }
+
+    func testLoadMoreIfNeededIsNoOpWhenItemFarFromEnd() throws {
+        let sourceId = try seedFeed(count: FeedItemsViewModel.pageSize * 3)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+
+        // Item near the top is well outside the prefetch window — no load.
+        let topItem = vm.items.first!
+        vm.loadMoreIfNeeded(currentItem: topItem)
+
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize)
+    }
+
+    func testRepeatedLoadMoreEventuallyExhausts() throws {
+        let total = FeedItemsViewModel.pageSize * 2 + 7  // not a clean multiple
+        let sourceId = try seedFeed(count: total)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+
+        // Drive pagination via the public API until exhausted.
+        var safety = 10
+        while vm.hasMoreItems && safety > 0 {
+            vm.loadMoreIfNeeded(currentItem: vm.items.last!)
+            safety -= 1
+        }
+
+        XCTAssertGreaterThan(safety, 0, "Pagination should exhaust without hitting safety counter")
+        XCTAssertEqual(vm.items.count, total, "All seeded rows must be reachable through pagination")
+        XCTAssertFalse(vm.hasMoreItems)
+    }
+
+    // MARK: - Source filter
+
+    func testPaginationRespectsSourceFilter() throws {
+        let _ = try seedFeed(count: 10)  // unrelated feed
+        let target = try seedFeed(count: 12)
+        let vm = FeedItemsViewModel()
+
+        vm.loadInitial(forSourceId: target)
+
+        XCTAssertEqual(vm.items.count, 12)
+        XCTAssertFalse(vm.hasMoreItems)
+        XCTAssertEqual(vm.items.first?.title, "Item 0000")
+    }
+
+    func testLoadInitialSwitchingSourceResetsState() throws {
+        let s1 = try seedFeed(count: 8)
+        let s2 = try seedFeed(count: 5)
+        let vm = FeedItemsViewModel()
+
+        vm.loadInitial(forSourceId: s1)
+        XCTAssertEqual(vm.items.count, 8)
+
+        vm.loadInitial(forSourceId: s2)
+        XCTAssertEqual(vm.items.count, 5, "Switching source must replace, not append")
+        XCTAssertEqual(vm.currentSourceId, s2)
+    }
+
+    func testLoadInitialIsIdempotentForSameSource() throws {
+        let sourceId = try seedFeed(count: FeedItemsViewModel.pageSize * 3)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+        vm.loadMoreIfNeeded(currentItem: vm.items.last!)
+        let countAfterTwoPages = vm.items.count
+
+        // Calling loadInitial again with the same source while items are
+        // already loaded must NOT re-fetch — preserves scroll position when
+        // the user navigates away and back.
+        vm.loadInitial(forSourceId: sourceId)
+        XCTAssertEqual(vm.items.count, countAfterTwoPages)
+    }
+
+    // MARK: - Refresh
+
+    func testRefreshResetsAndReloadsCurrentSource() async throws {
+        let sourceId = try seedFeed(count: FeedItemsViewModel.pageSize * 2)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+        vm.loadMoreIfNeeded(currentItem: vm.items.last!)
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize * 2)
+
+        await vm.refresh()
+
+        // After refresh, only the first page is loaded again, scoped to
+        // the same source.
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize)
+        XCTAssertEqual(vm.currentSourceId, sourceId)
+        XCTAssertTrue(vm.hasMoreItems)
+    }
+
+    // MARK: - All-articles view
+
+    func testNilSourceLoadsAcrossAllSources() throws {
+        _ = try seedFeed(count: 4)
+        _ = try seedFeed(count: 3)
+        let vm = FeedItemsViewModel()
+
+        vm.loadInitial(forSourceId: nil)
+
+        XCTAssertEqual(vm.items.count, 7, "Across all sources must aggregate")
+        XCTAssertNil(vm.currentSourceId)
+    }
+
+    // MARK: - Search
+
+    func testSearchFindsRowsBeyondLoadedPages() throws {
+        // 200 items, page size 50. Without SQL search, "Item 0150" would be
+        // unreachable from the search box because it's never paged in.
+        let sourceId = try seedFeed(count: 200)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize, "Only first page should be loaded")
+
+        vm.searchText = "Item 0150"
+        vm.performSearch()
+
+        XCTAssertEqual(vm.items.count, FeedItemsViewModel.pageSize, "Search must not mutate the paginated items list")
+        XCTAssertEqual(vm.filteredItems.count, 1, "Search must reach across the whole table, not just loaded pages")
+        XCTAssertEqual(vm.filteredItems.first?.title, "Item 0150")
+    }
+
+    func testSearchHitsFullContentSubstrings() throws {
+        let sourceId = try database.write { db -> Int64 in
+            try db.execute(
+                sql: "INSERT INTO rss_source (url, title) VALUES (?, ?)",
+                arguments: ["manual:feed:content-test", "Content Test"]
+            )
+            let id = db.lastInsertedRowID
+            try db.execute(
+                sql: """
+                    INSERT INTO feed_item (source_id, guid, title, link, pub_date, full_content)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [id, "g1", "alpha.swift", "manual:item:1", 1.0,
+                            "func magicTokenXYZ() {}"]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO feed_item (source_id, guid, title, link, pub_date, full_content)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [id, "g2", "beta.swift", "manual:item:2", 2.0,
+                            "let unrelated = 1"]
+            )
+            return id
+        }
+
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+        vm.searchText = "magicTokenXYZ"
+        vm.performSearch()
+
+        XCTAssertEqual(vm.filteredItems.count, 1)
+        XCTAssertEqual(vm.filteredItems.first?.title, "alpha.swift",
+                       "Search must hit full_content, not just title")
+    }
+
+    func testClearingSearchRestoresPaginatedItems() throws {
+        let sourceId = try seedFeed(count: 200)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+        vm.loadMoreIfNeeded(currentItem: vm.items.last!)
+        let loadedCount = vm.items.count
+
+        vm.searchText = "Item 0150"
+        vm.performSearch()
+        XCTAssertNotNil(vm.searchResults)
+
+        vm.searchText = ""
+        vm.performSearch()
+
+        XCTAssertNil(vm.searchResults, "Empty search must drop the result override")
+        XCTAssertEqual(vm.filteredItems.count, loadedCount,
+                       "Clearing search must reveal the previously paginated items, not reset them")
+    }
+
+    func testSearchEscapesLikeWildcards() throws {
+        let sourceId = try database.write { db -> Int64 in
+            try db.execute(
+                sql: "INSERT INTO rss_source (url, title) VALUES (?, ?)",
+                arguments: ["manual:feed:wildcard-test", "Wildcard Test"]
+            )
+            let id = db.lastInsertedRowID
+            try db.execute(
+                sql: """
+                    INSERT INTO feed_item (source_id, guid, title, link, pub_date, full_content)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [id, "g1", "literal_match.txt", "manual:item:1", 1.0, String(repeating: "x", count: 200)]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO feed_item (source_id, guid, title, link, pub_date, full_content)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [id, "g2", "literalAmatch.txt", "manual:item:2", 2.0, String(repeating: "x", count: 200)]
+            )
+            return id
+        }
+
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: sourceId)
+
+        // The literal `_` in the user query must NOT match `A` (the SQL
+        // wildcard semantics) — should only match the file with an actual
+        // underscore.
+        vm.searchText = "literal_match"
+        vm.performSearch()
+
+        XCTAssertEqual(vm.filteredItems.count, 1)
+        XCTAssertEqual(vm.filteredItems.first?.title, "literal_match.txt")
+    }
+
+    func testSearchRespectsSourceFilter() throws {
+        let s1 = try seedFeed(count: 10)
+        let s2 = try seedFeed(count: 10)
+        let vm = FeedItemsViewModel()
+        vm.loadInitial(forSourceId: s1)
+
+        vm.searchText = "Item 0003"
+        vm.performSearch()
+
+        XCTAssertEqual(vm.filteredItems.count, 1, "Only source s1 should match")
+        // Verify by switching to all-articles, where two items match:
+        vm.loadInitial(forSourceId: nil)
+        vm.searchText = "Item 0003"
+        vm.performSearch()
+        XCTAssertEqual(vm.filteredItems.count, 2, "Across all sources, both feeds match")
+        _ = s2
+    }
+}

--- a/NewsCombAppTests/FileImportServiceTests.swift
+++ b/NewsCombAppTests/FileImportServiceTests.swift
@@ -1,0 +1,374 @@
+import XCTest
+import GRDB
+@testable import NewsCombApp
+
+/// Unit tests for `FileImportService`. Uses an in-memory `DatabaseQueue` and
+/// a temp-directory fixture per test, so no live workspace is touched. We
+/// inject an `ArticleIngestionService` bound to the in-memory queue, exactly
+/// the way `ArticleIngestionServiceTests` does for the underlying service.
+final class FileImportServiceTests: XCTestCase {
+
+    private var dbQueue: DatabaseQueue!
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        var config = Configuration()
+        config.foreignKeysEnabled = true
+        dbQueue = try DatabaseQueue(configuration: config)
+        try dbQueue.write { db in
+            try Self.createSchema(db)
+        }
+
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileImportServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        tempRoot = nil
+        dbQueue = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Happy paths
+
+    func testImportsPlainTextAndCodeFiles() async throws {
+        try writeFile("README.md", text: longBody("This is the readme. "))
+        try writeFile("src/Main.swift", text: longBody("import Foundation\nfunc main() {}\n"))
+        try writeFile("scripts/build.py", text: longBody("print('hello world')\n"))
+        try writeFile("notes.txt", text: longBody("plain text content. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "My Project", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 4)
+        XCTAssertEqual(outcome.skippedTooShort, 0)
+        XCTAssertEqual(outcome.skippedUnreadable, 0)
+        XCTAssertEqual(outcome.skippedTooLarge, 0)
+        XCTAssertEqual(outcome.totalCandidates, 4)
+
+        try await dbQueue.read { db in
+            let sourceCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rss_source")!
+            XCTAssertEqual(sourceCount, 1, "Folder import must create exactly one manual feed")
+
+            let sourceURL = try String.fetchOne(db, sql: "SELECT url FROM rss_source")!
+            XCTAssertTrue(sourceURL.hasPrefix("manual:feed:"), "Source URL must use the manual scheme, got '\(sourceURL)'")
+
+            let itemCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feed_item WHERE source_id = ?", arguments: [outcome.sourceId])!
+            XCTAssertEqual(itemCount, 4)
+
+            // Titles are relative paths, so subfolder content should be distinguishable.
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item ORDER BY title")
+            XCTAssertTrue(titles.contains("README.md"))
+            XCTAssertTrue(titles.contains("notes.txt"))
+            XCTAssertTrue(titles.contains("scripts/build.py"))
+            XCTAssertTrue(titles.contains("src/Main.swift"))
+        }
+    }
+
+    func testRecursesIntoSubfolders() async throws {
+        try writeFile("a/b/c/deep.swift", text: longBody("nested file body. "))
+        try writeFile("a/shallow.md", text: longBody("shallow file body. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "Nested", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 2)
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item ORDER BY title")
+            XCTAssertEqual(titles, ["a/b/c/deep.swift", "a/shallow.md"])
+        }
+    }
+
+    // MARK: - Skip cases
+
+    func testSkipsFilesShorterThanMinimum() async throws {
+        try writeFile("tiny.md", text: "short")  // < 100 chars
+        try writeFile("ok.md", text: longBody("enough content. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 1)
+        XCTAssertEqual(outcome.skippedTooShort, 1)
+
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item")
+            XCTAssertEqual(titles, ["ok.md"])
+        }
+    }
+
+    func testSkipsUnsupportedExtensions() async throws {
+        try writeFile("image.png", text: "not really a png")
+        try writeFile("binary.exe", text: "not really exe")
+        // Log files are intentionally excluded — too noisy for the knowledge
+        // graph. Pinned here so re-adding "log" to plainTextExtensions
+        // produces a test failure instead of silent regression.
+        try writeFile("server.log", text: longBody("2026-05-09 ERROR something happened. "))
+        try writeFile("ok.swift", text: longBody("supported file. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 1)
+        XCTAssertEqual(outcome.totalCandidates, 1, "Only supported extensions should be candidates; .log must not be listed")
+
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item")
+            XCTAssertEqual(titles, ["ok.swift"], "Log file must not be ingested")
+        }
+    }
+
+    func testSkipsBinaryFileWithTextExtension() async throws {
+        // Write non-UTF-8 bytes to a .swift file. UTF-8 decoding must fail and
+        // the file must be reported as unreadable rather than crashing.
+        let badData = Data([0xFF, 0xFE, 0x00, 0x80, 0xC0, 0xC1] + Array(repeating: UInt8(0xFE), count: 200))
+        let url = tempRoot.appendingPathComponent("bad.swift")
+        try badData.write(to: url)
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 0)
+        XCTAssertEqual(outcome.skippedUnreadable, 1)
+
+        try await dbQueue.read { db in
+            let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feed_item")!
+            XCTAssertEqual(count, 0)
+        }
+    }
+
+    func testStripsHTMLContent() async throws {
+        let html = "<html><body><h1>Title</h1><p>" + String(repeating: "Hello world. ", count: 20) + "</p></body></html>"
+        try writeFile("page.html", text: html)
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "HTML", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 1)
+        try await dbQueue.read { db in
+            let body = try String.fetchOne(db, sql: "SELECT full_content FROM feed_item")!
+            XCTAssertFalse(body.contains("<p>"), "HTML tags must be stripped, got: \(body.prefix(120))")
+            XCTAssertFalse(body.contains("</body>"), "Closing tags must be stripped")
+            XCTAssertTrue(body.contains("Hello world"))
+        }
+    }
+
+    func testSkipsBuildDirectory() async throws {
+        // Codebases routinely have `build/` (Xcode CLI output, Gradle, CMake)
+        // and `.build/` (SwiftPM, Cargo) directories full of generated files.
+        // Importing them is noise — they must be pruned even if they contain
+        // files with supported extensions.
+        try writeFile("build/Generated.swift", text: longBody("auto-generated. "))
+        try writeFile("build/sub/dir/Other.swift", text: longBody("more auto-generated. "))
+        try writeFile(".build/checkouts/Lib/Lib.swift", text: longBody("vendored dep. "))
+        try writeFile("Sources/Real.swift", text: longBody("real source code. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 1)
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item ORDER BY title")
+            XCTAssertEqual(titles, ["Sources/Real.swift"],
+                           "build/ and .build/ subtrees must be pruned even when they hold .swift files")
+        }
+    }
+
+    func testSkipsLanguageSpecificDependencyAndOutputDirectories() async throws {
+        // Each excluded directory below holds a file with a supported
+        // extension. Only the sibling at the project root must survive.
+        // If someone removes an entry from `excludedDirectoryNames`, the
+        // corresponding line here will fail loudly.
+
+        // Generic build output
+        try writeFile("dist/bundle.js", text: longBody("compiled bundle. "))
+        try writeFile("out/output.swift", text: longBody("intellij output. "))
+        try writeFile("coverage/lcov.json", text: longBody("coverage report. "))
+
+        // Java / JVM
+        try writeFile("target/classes/App.java", text: longBody("maven output. "))
+        try writeFile("bin/Compiled.java", text: longBody("eclipse output. "))
+
+        // JS / TS
+        try writeFile("node_modules/lodash/index.js", text: longBody("dep tree. "))
+        try writeFile("node_modules/.bin/eslint.js", text: longBody("dep bin. "))
+
+        // Python
+        try writeFile("__pycache__/module.cpython-311.py", text: longBody("bytecode-adjacent. "))
+        try writeFile("venv/lib/python3.11/site-packages/pkg.py", text: longBody("venv dep. "))
+
+        // Go / PHP / Ruby
+        try writeFile("vendor/github.com/foo/bar/lib.go", text: longBody("vendored dep. "))
+
+        // The one file that should win.
+        try writeFile("src/Real.swift", text: longBody("actual source. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        XCTAssertEqual(outcome.ingested, 1, "Only files outside excluded directories should be ingested")
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item")
+            XCTAssertEqual(titles, ["src/Real.swift"])
+        }
+    }
+
+    func testSkipsHiddenAndPackageDescendants() async throws {
+        try writeFile(".git/HEAD", text: longBody("git ref content. "))
+        try writeFile(".hidden.md", text: longBody("hidden markdown. "))
+        try writeFile("Example.xcodeproj/project.pbxproj", text: longBody("pbxproj body. "))
+        try writeFile("public.swift", text: longBody("visible swift file. "))
+
+        let service = makeService()
+        let outcome = try await service.importFolder(rootURL: tempRoot, feedTitle: "F", progress: nil)
+
+        // Only public.swift should be ingested; .git, .hidden.md, and the
+        // .xcodeproj package descendant are filtered out by the enumerator
+        // options (.skipsHiddenFiles + .skipsPackageDescendants).
+        XCTAssertEqual(outcome.ingested, 1)
+        try await dbQueue.read { db in
+            let titles = try String.fetchAll(db, sql: "SELECT title FROM feed_item")
+            XCTAssertEqual(titles, ["public.swift"])
+        }
+    }
+
+    // MARK: - Idempotency
+
+    func testReimportingSameFolderUpdatesContentInPlace() async throws {
+        // First pass establishes the manual feed and its articles.
+        try writeFile("doc.md", text: longBody("first revision. "))
+        let service = makeService()
+        let first = try await service.importFolder(rootURL: tempRoot, feedTitle: "Pass1", progress: nil)
+
+        // Re-import into the *same* feed by reusing the source id directly via
+        // the underlying ArticleIngestionService. (The UI always creates a
+        // fresh feed; this test exercises the upsert path that is reachable
+        // via MCP today and via a future "re-import into existing feed" UI.)
+        try writeFile("doc.md", text: longBody("second revision content. "))
+        let ingestion = makeIngestionService()
+        let body = try String(contentsOf: tempRoot.appendingPathComponent("doc.md"), encoding: .utf8)
+        _ = try ingestion.ingestArticle(
+            sourceId: first.sourceId,
+            title: "doc.md",
+            body: body,
+            link: tempRoot.appendingPathComponent("doc.md").absoluteString,
+            author: nil,
+            pubDate: nil,
+            guid: "doc.md"
+        )
+
+        try await dbQueue.read { db in
+            let rowCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feed_item WHERE source_id = ?", arguments: [first.sourceId])!
+            XCTAssertEqual(rowCount, 1, "Same (source_id, guid) must upsert in place")
+            let storedBody = try String.fetchOne(db, sql: "SELECT full_content FROM feed_item WHERE source_id = ?", arguments: [first.sourceId])!
+            XCTAssertTrue(storedBody.contains("second revision"), "Body must reflect the second revision after upsert")
+        }
+    }
+
+    // MARK: - Progress callback
+
+    func testProgressCallbackFiresPerFile() async throws {
+        try writeFile("a.md", text: longBody("a body. "))
+        try writeFile("b.md", text: longBody("b body. "))
+        try writeFile("c.md", text: longBody("c body. "))
+
+        let service = makeService()
+        let collector = ProgressCollector()
+        // The callback signature is `@MainActor (...) -> Void` — sync. Both
+        // the closure and `collector.append` are MainActor-isolated, so the
+        // call doesn't need `await`; adding one would force the closure to
+        // become async and mismatch the typealias.
+        _ = try await service.importFolder(rootURL: tempRoot, feedTitle: "F") { processed, total, _ in
+            collector.append(processed: processed, total: total)
+        }
+
+        let snapshots = await collector.snapshots
+        XCTAssertEqual(snapshots.count, 3, "Callback must fire once per candidate")
+        XCTAssertEqual(snapshots.map(\.processed), [1, 2, 3])
+        XCTAssertEqual(Set(snapshots.map(\.total)), [3])
+    }
+
+    // MARK: - Helpers
+
+    /// Pads a seed string until it comfortably exceeds
+    /// `ArticleIngestionService.minimumBodyLength` (100 chars).
+    private func longBody(_ seed: String) -> String {
+        var s = seed
+        while s.count < 150 { s += seed }
+        return s
+    }
+
+    private func writeFile(_ relativePath: String, text: String) throws {
+        let url = tempRoot.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeIngestionService() -> ArticleIngestionService {
+        ArticleIngestionService(
+            dbQueue: dbQueue,
+            extract: { _ in ExtractionResult(content: nil, finalURL: nil) }
+        )
+    }
+
+    private func makeService() -> FileImportService {
+        FileImportService(ingestionService: makeIngestionService())
+    }
+
+    /// Schema mirrors what `ArticleIngestionServiceTests` builds — only the
+    /// three tables `ArticleIngestionService` writes to. Keep these two
+    /// schema definitions in sync if the production schema evolves.
+    private static func createSchema(_ db: GRDB.Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE rss_source (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT NOT NULL UNIQUE,
+                title TEXT,
+                created_at REAL NOT NULL DEFAULT (unixepoch())
+            );
+            CREATE TABLE feed_item (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id INTEGER NOT NULL REFERENCES rss_source(id) ON DELETE CASCADE,
+                guid TEXT NOT NULL,
+                title TEXT NOT NULL,
+                link TEXT NOT NULL,
+                pub_date REAL,
+                rss_description TEXT,
+                full_content TEXT,
+                author TEXT,
+                fetched_at REAL NOT NULL DEFAULT (unixepoch()),
+                UNIQUE(source_id, guid)
+            );
+            CREATE TABLE article_hypergraph (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                feed_item_id INTEGER NOT NULL REFERENCES feed_item(id) ON DELETE CASCADE,
+                processed_at REAL NOT NULL DEFAULT (unixepoch()),
+                processing_status TEXT NOT NULL DEFAULT 'pending',
+                error_message TEXT,
+                chunk_count INTEGER DEFAULT 0,
+                UNIQUE(feed_item_id)
+            );
+        """)
+    }
+}
+
+/// Small actor used to collect progress callback invocations from the test.
+/// The callback is `@MainActor`, so the actor's `append` must hop to the
+/// main actor too — easiest to make the whole collector main-actor-isolated.
+@MainActor
+private final class ProgressCollector {
+    struct Snapshot { let processed: Int; let total: Int }
+    var snapshots: [Snapshot] = []
+    func append(processed: Int, total: Int) {
+        snapshots.append(Snapshot(processed: processed, total: total))
+    }
+}

--- a/NewsCombAppTests/GraphViewModelFilterTests.swift
+++ b/NewsCombAppTests/GraphViewModelFilterTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import NewsCombApp
+
+/// Exercises `GraphViewModel.filterVisibleNodes`, the pure filter helper
+/// that backs `visibleNodes`. Tested via the static API to avoid
+/// instantiating the view model (which touches `Database.current`).
+final class GraphViewModelFilterTests: XCTestCase {
+
+    private func node(_ id: Int64, degree: Int = 0) -> GraphNode {
+        var n = GraphNode(id: id, label: "Node \(id)", nodeType: nil)
+        n.degree = degree
+        return n
+    }
+
+    // MARK: - Threshold mode (default)
+
+    func testThresholdModeRespectsMinDegree() {
+        let nodes = [node(1, degree: 1), node(2, degree: 5), node(3, degree: 10)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: false,
+            showingLongestPathsOnly: false,
+            matchedNodeIds: [],
+            expandedNodeIds: [],
+            longestPathNodeIds: [],
+            connectionThreshold: 5
+        )
+
+        XCTAssertEqual(Set(visible.map(\.id)), Set([2, 3]))
+    }
+
+    func testThresholdModeIncludesExpandedBelowThreshold() {
+        let nodes = [node(1, degree: 1), node(2, degree: 5)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: false,
+            showingLongestPathsOnly: false,
+            matchedNodeIds: [],
+            expandedNodeIds: [1],
+            longestPathNodeIds: [],
+            connectionThreshold: 5
+        )
+
+        // Node 1 is below threshold but is expanded → included.
+        XCTAssertEqual(Set(visible.map(\.id)), Set([1, 2]))
+    }
+
+    // MARK: - Matches-only mode
+
+    func testMatchesOnlyShowsMatchesAndExpandedUnion() {
+        // Node 1 matches search (yellow), node 2 was expanded via double-click,
+        // node 3 is unrelated (high degree but no match, no expansion).
+        let nodes = [node(1, degree: 1), node(2, degree: 1), node(3, degree: 99)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: true,
+            showingLongestPathsOnly: false,
+            matchedNodeIds: [1],
+            expandedNodeIds: [2],
+            longestPathNodeIds: [],
+            connectionThreshold: 1
+        )
+
+        XCTAssertEqual(Set(visible.map(\.id)), Set([1, 2]))
+    }
+
+    func testMatchesOnlyIgnoresThreshold() {
+        // High-degree node 3 must NOT appear when matches-only is on,
+        // even though it would dominate threshold mode.
+        let nodes = [node(1, degree: 1), node(2, degree: 1), node(3, degree: 99)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: true,
+            showingLongestPathsOnly: false,
+            matchedNodeIds: [1],
+            expandedNodeIds: [],
+            longestPathNodeIds: [],
+            connectionThreshold: 1
+        )
+
+        XCTAssertEqual(visible.map(\.id), [1])
+    }
+
+    func testMatchesOnlyWithNoMatchesAndNoExpansionsIsEmpty() {
+        let nodes = [node(1, degree: 5), node(2, degree: 5)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: true,
+            showingLongestPathsOnly: false,
+            matchedNodeIds: [],
+            expandedNodeIds: [],
+            longestPathNodeIds: [],
+            connectionThreshold: 1
+        )
+
+        XCTAssertTrue(visible.isEmpty)
+    }
+
+    // MARK: - Mode precedence
+
+    func testMatchesOnlyTakesPrecedenceOverLongestPaths() {
+        // If both flags are accidentally set, matches-only wins
+        // (matches both the precedence in `filterVisibleNodes` and the
+        // mutual-exclusion guards in the toggle methods).
+        let nodes = [node(1, degree: 1), node(2, degree: 1), node(3, degree: 1)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: true,
+            showingLongestPathsOnly: true,
+            matchedNodeIds: [1],
+            expandedNodeIds: [],
+            longestPathNodeIds: [2, 3],
+            connectionThreshold: 1
+        )
+
+        XCTAssertEqual(visible.map(\.id), [1])
+    }
+
+    func testLongestPathsModeIgnoresMatches() {
+        let nodes = [node(1, degree: 1), node(2, degree: 1), node(3, degree: 1)]
+
+        let visible = GraphViewModel.filterVisibleNodes(
+            nodes,
+            showingMatchesOnly: false,
+            showingLongestPathsOnly: true,
+            matchedNodeIds: [1],
+            expandedNodeIds: [],
+            longestPathNodeIds: [2, 3],
+            connectionThreshold: 1
+        )
+
+        XCTAssertEqual(Set(visible.map(\.id)), Set([2, 3]))
+    }
+}

--- a/NewsCombAppTests/LongestPathFinderTests.swift
+++ b/NewsCombAppTests/LongestPathFinderTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import NewsCombApp
+
+final class LongestPathFinderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func node(_ id: Int64) -> GraphNode {
+        GraphNode(id: id, label: "Node \(id)", nodeType: nil)
+    }
+
+    private func edge(_ id: Int64, from: Int64, to: Int64) -> GraphEdge {
+        GraphEdge(
+            id: id,
+            edgeId: "e\(id)",
+            label: "rel",
+            sourceNodeIds: [from],
+            targetNodeIds: [to]
+        )
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmptyGraphReturnsNoPaths() {
+        let result = LongestPathFinder.topLongestPaths(nodes: [], edges: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testGraphWithNoEdgesReturnsNoPaths() {
+        let nodes = [node(1), node(2)]
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testZeroCountReturnsNoPaths() {
+        let nodes = [node(1), node(2)]
+        let edges = [edge(1, from: 1, to: 2)]
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 0)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Correctness
+
+    func testSimpleChainProducesFullPath() {
+        // 1 -- 2 -- 3 -- 4 -- 5
+        let nodes = (1...5).map { node(Int64($0)) }
+        let edges = [
+            edge(1, from: 1, to: 2),
+            edge(2, from: 2, to: 3),
+            edge(3, from: 3, to: 4),
+            edge(4, from: 4, to: 5)
+        ]
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 1)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].count, 5, "Longest path should traverse all 5 nodes")
+        XCTAssertEqual(Set(result[0]), Set([1, 2, 3, 4, 5]))
+    }
+
+    func testEdgesAreTreatedAsUndirected() {
+        // Direction shouldn't matter: a -> b -> c should still find a path of 3.
+        let nodes = [node(1), node(2), node(3)]
+        let edges = [
+            edge(1, from: 1, to: 2),
+            edge(2, from: 3, to: 2)  // reversed direction at 3
+        ]
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 1)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].count, 3)
+    }
+
+    func testReturnsSortedDescending() {
+        // Two disconnected components: a chain of 4 and a chain of 2.
+        let nodes = (1...6).map { node(Int64($0)) }
+        let edges = [
+            edge(1, from: 1, to: 2),
+            edge(2, from: 2, to: 3),
+            edge(3, from: 3, to: 4),
+            edge(4, from: 5, to: 6)
+        ]
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 5)
+
+        XCTAssertGreaterThanOrEqual(result.count, 2)
+        for i in 1..<result.count {
+            XCTAssertGreaterThanOrEqual(
+                result[i - 1].count,
+                result[i].count,
+                "Paths must be sorted longest-first"
+            )
+        }
+    }
+
+    func testRespectsMaxDepth() {
+        // Chain of 10, but we cap depth at 4.
+        let nodes = (1...10).map { node(Int64($0)) }
+        let edges = (1..<10).map { i in edge(Int64(i), from: Int64(i), to: Int64(i + 1)) }
+
+        let result = LongestPathFinder.topLongestPaths(
+            nodes: nodes,
+            edges: edges,
+            count: 1,
+            maxDepth: 4
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertLessThanOrEqual(result[0].count, 4)
+    }
+
+    func testDoesNotRevisitNodesInPath() {
+        // Triangle: any path can have at most 3 nodes (no repeats).
+        let nodes = [node(1), node(2), node(3)]
+        let edges = [
+            edge(1, from: 1, to: 2),
+            edge(2, from: 2, to: 3),
+            edge(3, from: 3, to: 1)
+        ]
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 1)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].count, 3)
+        XCTAssertEqual(Set(result[0]).count, 3, "No node should appear twice in a simple path")
+    }
+
+    func testHyperedgeConnectsAllSourcesToAllTargets() {
+        // Hyperedge with sources {1,2} and targets {3,4} creates 4 pairs:
+        // (1,3) (1,4) (2,3) (2,4). A long simple path should exist using
+        // these pairs across all four nodes.
+        let nodes = [node(1), node(2), node(3), node(4)]
+        let hyperedge = GraphEdge(
+            id: 1,
+            edgeId: "h1",
+            label: "rel",
+            sourceNodeIds: [1, 2],
+            targetNodeIds: [3, 4]
+        )
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: [hyperedge], count: 1)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].count, 4, "All 4 nodes should be reachable via the hyperedge")
+    }
+
+    func testDeduplicatesPathsWithSameNodeSet() {
+        // Triangle 1-2-3 has paths [1,2,3], [2,3,1], [3,1,2] etc.
+        // All share the same node-set; only one should be returned.
+        let nodes = [node(1), node(2), node(3)]
+        let edges = [
+            edge(1, from: 1, to: 2),
+            edge(2, from: 2, to: 3),
+            edge(3, from: 3, to: 1)
+        ]
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 10)
+
+        XCTAssertEqual(result.count, 1, "Identical node-sets should be deduplicated")
+    }
+
+    func testCountLimitsResults() {
+        // Build several disjoint chains of varying lengths.
+        var nodes: [GraphNode] = []
+        var edges: [GraphEdge] = []
+        var nextId: Int64 = 1
+        var nextEdgeId: Int64 = 1
+        for length in 2...6 {
+            let start = nextId
+            for offset in 0..<length {
+                nodes.append(node(start + Int64(offset)))
+            }
+            for offset in 0..<(length - 1) {
+                edges.append(edge(
+                    nextEdgeId,
+                    from: start + Int64(offset),
+                    to: start + Int64(offset + 1)
+                ))
+                nextEdgeId += 1
+            }
+            nextId += Int64(length)
+        }
+
+        let result = LongestPathFinder.topLongestPaths(nodes: nodes, edges: edges, count: 3)
+
+        XCTAssertLessThanOrEqual(result.count, 3)
+    }
+}


### PR DESCRIPTION
## Summary

Two unrelated pieces in one branch (per request).

### 1. UI folder import with pagination and full-table search
Surfaces the existing MCP `create_manual_feed` + `ingest_article` flow in the main window, plus the display-side fixes that the import surfaced.

- **Folder picker → manual feed.** New `FileImportService` walks a folder, extracts text per file (UTF-8 for plain/code/markdown, `strippingHTMLTags()` for HTML, PDFKit for PDF), and ingests via the existing `ArticleIngestionService` so the resulting feed is byte-for-byte identical to one created via MCP.
- **Sensible exclusions.** Hidden files, package descendants (`.xcodeproj`, etc.), `.log` files, and a denylist of build/cache directories: `build`, `dist`, `out`, `target`, `bin`, `node_modules`, `__pycache__`, `venv`, `vendor`, `coverage`. 5 MB per-file cap. Relative path is used as `guid` so re-importing upserts in place.
- **Idempotent re-imports.** Same `(source_id, guid)` upsert as MCP — re-importing a folder updates changed files instead of duplicating.
- **Infinite scroll.** `FeedItemsViewModel`'s hardcoded `.limit(100)` is replaced with offset-based pagination + `onAppear`-driven prefetch. Without this, importing a 400-file codebase silently hid most of it from the UI.
- **Full-table search.** Search box now runs a SQL `LIKE` query against `title` + `full_content` across the whole `feed_item` table for the current source, so typing reaches rows that haven't been paged in yet. `%`/`_`/`\` in user input are escaped.
- 29 new tests in `FileImportServiceTests` and `FeedItemsViewModelPaginationTests` covering ingestion, recursion, exclusions (build directories per language, log files, hidden files, package descendants), idempotency, pagination, search-across-pages, source-filter scoping, and wildcard escaping.

### 2. Graph: longest-paths and matches-only filter modes
Heuristic top-N longest simple paths via bounded DFS (NP-hard exactly, so traded for predictable cost), wired into `GraphViewModel` along with new threshold-mode tweaks and a matches-only filter. UI updates in `GraphSearchOverlay` and `GraphVisualizationView`.

## Test plan
- [ ] `xcodebuild test -scheme NewsCombApp -destination 'platform=macOS,arch=arm64' -skip-testing:NewsCombAppUITests` — local run is green for the suites touched here (`FileImportServiceTests`, `FeedItemsViewModelPaginationTests`, `ArticleIngestionServiceTests`, `LongestPathFinderTests`, `GraphViewModelFilterTests`); CI to confirm full suite.
- [ ] Manual smoke: import a folder with hundreds of files, scroll the resulting feed, search for a token only present in a deeply-nested file's content, click "Process Knowledge Graph", verify graph node count grows.
- [ ] Manual smoke: open the graph visualization, exercise the new longest-paths and matches-only filter modes.