### PR TITLE
docs: correct hypergraph paper citations in README and blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,16 @@ Add the same configuration to your Claude Desktop settings file:
 
 This project is inspired by and builds upon the hypergraph reasoning approach described in:
 
-**[HyperGraphRAG: Hypergraph-Driven Reasoning and Affordable LLM-Based Knowledge Construction](https://arxiv.org/pdf/2601.04878)**
+**[Higher-Order Knowledge Representations for Agentic Scientific Reasoning](https://arxiv.org/abs/2601.04878)**
 
-> Buehler, M.J. (2025). A novel approach using hypergraphs for knowledge organization and reasoning, enabling multi-hop traversal and affordable construction via small language models.
+> Stewart, I.A. & Buehler, M.J. (2026). Constructing hypergraph-based knowledge representations that faithfully encode multi-entity relationships, with agentic traversal via node-intersection constraints. arXiv:2601.04878v1.
 
 The original Python implementation is available at: [lamm-mit/HyperGraphReasoning](https://github.com/lamm-mit/HyperGraphReasoning)
+
+Related work that informed the design:
+
+- **[HyperGraphRAG: Retrieval-Augmented Generation via Hypergraph-Structured Knowledge Representation](https://arxiv.org/abs/2503.21322)** — Luo, H., E, H., Chen, G., et al. (2025). Represents n-ary relational facts as hyperedges with separate vector indexes for entities and hyperedges. arXiv:2503.21322v3.
+- **[Do We Still Need GraphRAG? Benchmarking RAG and GraphRAG for Agentic Search Systems](https://arxiv.org/abs/2604.09666)** — Fan, D., Xue, Z., Liu, S., & Tan, Q. (2026). Comparative evaluation of RAG versus GraphRAG for agentic search systems. arXiv:2604.09666v1.
 
 ### Technical Resources
 

--- a/docs/blog-post.md
+++ b/docs/blog-post.md
@@ -38,7 +38,7 @@ The real output: turning strategic awareness from an editorial process (humans r
 
 ## The Research Foundation
 
-We built on the **HyperGraphRAG** framework (Buehler, 2025), which introduced hypergraph-driven reasoning with affordable LLM-based knowledge construction. The paper demonstrated that small language models can extract high-quality Subject-Verb-Object triples from text, and that hypergraph topology enables multi-hop reasoning that traditional RAG cannot. This section covers the core algorithmic ideas that make the system work.
+We built on the hypergraph reasoning framework described by Stewart & Buehler (2026) in *Higher-Order Knowledge Representations for Agentic Scientific Reasoning*, which constructs hypergraph-based knowledge representations that faithfully encode multi-entity relationships and enables agentic reasoning via node-intersection graph traversal. The approach showed that small language models can extract high-quality Subject-Verb-Object triples from text, and that hypergraph topology enables multi-hop reasoning that traditional RAG cannot. This section covers the core algorithmic ideas that make the system work.
 
 ### Why a Hypergraph?
 
@@ -363,7 +363,9 @@ The pure-Swift implementation (`Services/UMAPService.swift` ~ 390 LOC) collapsed
 
 ## References
 
-- Buehler, M.J. (2025). "HyperGraphRAG: Hypergraph-Driven Reasoning and Affordable LLM-Based Knowledge Construction." arXiv:2601.04878.
+- Stewart, I.A., & Buehler, M.J. (2026). "Higher-Order Knowledge Representations for Agentic Scientific Reasoning." arXiv:2601.04878.
+- Luo, H., E, H., Chen, G., et al. (2025). "HyperGraphRAG: Retrieval-Augmented Generation via Hypergraph-Structured Knowledge Representation." arXiv:2503.21322.
+- Fan, D., Xue, Z., Liu, S., & Tan, Q. (2026). "Do We Still Need GraphRAG? Benchmarking RAG and GraphRAG for Agentic Search Systems." arXiv:2604.09666.
 - McInnes, L., Healy, J., & Melville, J. (2018). "UMAP: Uniform Manifold Approximation and Projection for Dimension Reduction." arXiv:1802.03426.
 - Grootendorst, M. (2022). "BERTopic: Neural topic modeling with a class-based TF-IDF procedure."
 - Campello, R.J.G.B., Moulavi, D., & Sander, J. (2013). "Density-Based Clustering Based on Hierarchical Density Estimates." PAKDD 2013.


### PR DESCRIPTION
## What

The "Research Foundation" citation paired **arXiv:2601.04878** with the title of a *different* paper ("HyperGraphRAG: Hypergraph-Driven Reasoning and Affordable LLM-Based Knowledge Construction"). arXiv:2601.04878 is actually **"Higher-Order Knowledge Representations for Agentic Scientific Reasoning"** by Stewart & Buehler (2026) — the paper that `lamm-mit/HyperGraphReasoning` (the Python code this project's `HyperGraphReasoning` Swift package descends from) references in its README.

## Changes

- **README.md** — fix the primary "Research Foundation" citation (title, authors, year; link now points to `arxiv.org/abs/`). Add a "Related work that informed the design" subsection.
- **docs/blog-post.md** — rewrite the body reference (§"The Research Foundation") to describe the actual paper (multi-entity relationship encoding, node-intersection graph traversal) instead of the borrowed title's phrasing. Update the References list.
- Add two related-work citations across both docs:
  - Luo, H., E, H., Chen, G., et al. — "HyperGraphRAG: Retrieval-Augmented Generation via Hypergraph-Structured Knowledge Representation" (arXiv:2503.21322v3, NeurIPS 2025)
  - Fan, D., Xue, Z., Liu, S., & Tan, Q. — "Do We Still Need GraphRAG? Benchmarking RAG and GraphRAG for Agentic Search Systems" (arXiv:2604.09666v1, 2026)

## Notes

Docs-only change — no code, no tests affected.